### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "paper-styles": "polymerelements/paper-styles#^1.0.2",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-    "web-component-tester": "*",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   },
   "ignore": []

--- a/demo/simple-fit.html
+++ b/demo/simple-fit.html
@@ -9,14 +9,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../iron-fit-behavior.html">
-<link rel="import" href="../../paper-styles/paper-styles.html">
+<link rel="import" href="../../paper-styles/color.html">
+<link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
 
 <dom-module id="simple-fit">
 
   <style>
     :host {
       @apply(--layout);
-      
+
       background-color: var(--paper-light-blue-500);
       color: white;
       text-align: center;

--- a/test/iron-fit-behavior.html
+++ b/test/iron-fit-behavior.html
@@ -20,9 +20,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="../../webcomponentsjs/webcomponents.js"></script>
 
     <script src="../../web-component-tester/browser.js"></script>
-    <script src="../../test-fixture/test-fixture-mocha.js"></script>
-
-    <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="test-fit.html">
 
     <style>


### PR DESCRIPTION
Fixes the generic usage of `paper-styles.html` and `/deep/` classes and uses the specific imports instead. Also updates the test to the new `wct#^3.4.0` way