### PR TITLE
center according to parent's stacking context

### DIFF
--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -239,18 +239,30 @@ CSS properties               | Action
      * `position:fixed`.
      */
     center: function() {
-      if (!this._fitInfo.positionedBy.vertically || !this._fitInfo.positionedBy.horizontally) {
-        // need position:fixed to center
-        this.style.position = 'fixed';
+      var positionedBy = this._fitInfo.positionedBy;
+      if (positionedBy.vertically && positionedBy.horizontally) {
+        // Already positioned.
+        return;
       }
-      if (!this._fitInfo.positionedBy.vertically) {
-        var top = (this._fitHeight - this.offsetHeight) / 2 + this._fitTop;
-        top -= this._fitInfo.margin.top;
+      // Need position:fixed to center
+      this.style.position = 'fixed';
+      // Take into account the offset caused by parents that create stacking
+      // contexts (e.g. with transform: translate3d). Translate to 0,0 and
+      // measure the bounding rect.
+      if (!positionedBy.vertically) {
+        this.style.top = '0px';
+      }
+      if (!positionedBy.horizontally) {
+        this.style.left = '0px';
+      }
+      // It will take in consideration margins and transforms
+      var rect = this.getBoundingClientRect();
+      if (!positionedBy.vertically) {
+        var top = this._fitTop - rect.top + (this._fitHeight - rect.height) / 2;
         this.style.top = top + 'px';
       }
-      if (!this._fitInfo.positionedBy.horizontally) {
-        var left = (this._fitWidth - this.offsetWidth) / 2 + this._fitLeft;
-        left -= this._fitInfo.margin.left;
+      if (!positionedBy.horizontally) {
+        var left = this._fitLeft - rect.left + (this._fitWidth - rect.width) / 2;
         this.style.left = left + 'px';
       }
     }

--- a/test/iron-fit-behavior.html
+++ b/test/iron-fit-behavior.html
@@ -46,6 +46,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         height: 200px;
       }
 
+      .sized-xy {
+        width: 200px;
+        height: 200px;
+      }
+
       .positioned-left {
         position: absolute;
         left: 100px;
@@ -148,7 +153,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <test-fixture id="constrain-target">
       <template>
         <div class="constrain" style="position: fixed; top: 20px; left: 100px; width: 50vw; height: 50vh; border: 1px solid black;">
-          <test-fit auto-fit-on-attach class="el">
+          <test-fit auto-fit-on-attach class="el sized-xy">
             <div>
               Auto center/center to parent element
             </div>
@@ -232,6 +237,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var rect = el.getBoundingClientRect();
           assert.closeTo(rect.left - (window.innerWidth - rect.right), 0, 5, 'centered horizontally');
           assert.closeTo(rect.top - (window.innerHeight - rect.bottom), 0, 5, 'centered vertically');
+        });
+
+        test('sized element with transformed parent is centered in viewport', function() {
+          var constrain = fixture('constrain-target');
+          var el = Polymer.dom(constrain).querySelector('.el');
+          var rectBefore = el.getBoundingClientRect();
+          constrain.style.transform = 'translate3d(5px, 5px, 0)';
+          el.center();
+          var rectAfter = el.getBoundingClientRect();
+          assert.equal(rectBefore.top, rectAfter.top, 'top ok');
+          assert.equal(rectBefore.bottom, rectAfter.bottom, 'bottom ok');
+          assert.equal(rectBefore.left, rectAfter.left, 'left ok');
+          assert.equal(rectBefore.right, rectAfter.right, 'right ok');
         });
 
         test('scrolling element is centered in viewport', function() {


### PR DESCRIPTION
Take in consideration parent's `transform` that will affect the position of the element. 
Done by setting `top/left` to `0px` and then using `getBoundingClientRect`; this will also take care of the margins.