### PR TITLE
show what's showable

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -56,7 +56,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           z-index: 10;
           padding: 20px;
           overflow: auto;
-          width: 220px;
+          min-width: 220px;
+          min-height: 100px;
         }
       </style>
       <template is="dom-bind">

--- a/demo/index.html
+++ b/demo/index.html
@@ -24,6 +24,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
 
   <style is="custom-style" include="demo-pages-shared-styles">
+    .centered {
+      min-width: 500px;
+    }
     demo-snippet {
       --demo-snippet-code: {
         max-height: 250px;
@@ -56,7 +59,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           z-index: 10;
           padding: 20px;
           overflow: auto;
-          min-width: 220px;
+          min-width: 100px;
           min-height: 100px;
         }
       </style>

--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -386,11 +386,11 @@ Use `noOverlap` to position the element around another element without overlappi
         }
       }
       if (top < margin.top) {
+        top = margin.top;
         if (bottom - top < minHeight) {
           top = bottom - minHeight;
         }
       }
-
 
       this.sizingTarget.style.maxWidth = (right - left) + 'px';
       this.sizingTarget.style.maxHeight = (bottom - top) + 'px';

--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -335,9 +335,11 @@ Use `noOverlap` to position the element around another element without overlappi
       var positionRect = this.__getNormalizedRect(this.positionTarget);
       var fitRect = this.__getNormalizedRect(this.fitInto);
 
+      var margin = this._fitInfo.margin;
+
       // Consider the margin as part of the size for position calculations.
-      var width = rect.width + this._fitInfo.margin.left + this._fitInfo.margin.right;
-      var height = rect.height + this._fitInfo.margin.top + this._fitInfo.margin.bottom;
+      var width = rect.width + margin.left + margin.right;
+      var height = rect.height + margin.top + margin.bottom;
 
       var alignRight = this.__isAlignRight(this._localeHorizontalAlign, width, positionRect, fitRect);
       var alignBottom = this.__isAlignBottom(this.verticalAlign, height, positionRect, fitRect);
@@ -368,33 +370,30 @@ Use `noOverlap` to position the element around another element without overlappi
         }
       }
 
-      left += this._fitInfo.margin.left;
-      top += this._fitInfo.margin.top;
+      left += margin.left;
+      top += margin.top;
 
       // Use original size (without margin)
-      var right = left + rect.width;
-      var bottom = top + rect.height;
-
-      left = Math.max(left, this._fitInfo.margin.left);
-      top = Math.max(top, this._fitInfo.margin.top);
-
-      var maxWidth = Math.min(fitRect.right - this._fitInfo.margin.right, right) - left;
-      var maxHeight = Math.min(fitRect.bottom - this._fitInfo.margin.bottom, bottom) - top;
+      var right = Math.min(fitRect.right - margin.right, left + rect.width);
+      var bottom = Math.min(fitRect.bottom - margin.bottom, top + rect.height);
 
       var minWidth = this._fitInfo.sizedBy.minWidth;
       var minHeight = this._fitInfo.sizedBy.minHeight;
-
-      if (maxWidth < minWidth || right < minWidth) {
-        left = -9999;
-        maxWidth = 0;
+      if (left < margin.left) {
+        left = margin.left;
+        if (right - left < minWidth) {
+          left = right - minWidth;
+        }
       }
-      if (maxHeight < minHeight || bottom < minHeight) {
-        top = -9999;
-        maxHeight = 0;
+      if (top < margin.top) {
+        if (bottom - top < minHeight) {
+          top = bottom - minHeight;
+        }
       }
 
-      this.sizingTarget.style.maxWidth = maxWidth + 'px';
-      this.sizingTarget.style.maxHeight = maxHeight + 'px';
+
+      this.sizingTarget.style.maxWidth = (right - left) + 'px';
+      this.sizingTarget.style.maxHeight = (bottom - top) + 'px';
 
       // Remove the offset caused by any stacking context.
       this.style.left = (left - rect.left) + 'px';

--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -506,10 +506,7 @@ Use `noOverlap` to position the element around another element without overlappi
     },
 
     __isAlignRight: function(hAlign, size, positionRect, fitRect) {
-      if (hAlign === 'right') {
-        return true;
-      }
-      if (hAlign === 'auto') {
+      if (!hAlign || hAlign === 'auto') {
         // We should align on the right if positionTarget is on the right of fitInto,
         // or if we can overlap and aligning on the left would cause more cropping
         // than aligning on the right.
@@ -520,14 +517,11 @@ Use `noOverlap` to position the element around another element without overlappi
         return positionTargetCenter > fitIntoCenter ||
           (!this.noOverlap && croppedLeft > croppedRight);
       }
-      return false;
+      return hAlign === 'right';
     },
 
     __isAlignBottom: function(vAlign, size, positionRect, fitRect) {
-      if (vAlign === 'bottom') {
-        return true;
-      }
-      if (vAlign === 'auto') {
+      if (!vAlign || vAlign === 'auto') {
         // We should align on the bottom if positionTarget is on the bottom of fitInto,
         // or if we can overlap and aligning on the top would cause more cropping
         // than aligning on the bottom.
@@ -538,7 +532,7 @@ Use `noOverlap` to position the element around another element without overlappi
         return positionTargetCenter > fitIntoCenter ||
           (!this.noOverlap && croppedTop > croppedBottom);
       }
-      return false;
+      return vAlign === 'bottom';
     },
 
     __getCroppedArea: function(rect, fitRect) {

--- a/test/iron-fit-behavior.html
+++ b/test/iron-fit-behavior.html
@@ -486,13 +486,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.isBelow(rect.height, elRect.height, 'height ok');
           });
 
-          test('min-height is respected: element is hidden if does not have enough height', function() {
+          test('min-height is preserved: element is displayed even if partially', function() {
             parent.style.top = '-10px';
             el.verticalAlign = 'top';
             el.style.minHeight = elRect.height + 'px';
             el.refit();
             var rect = el.getBoundingClientRect();
-            assert.isFalse(intersects(rect, fitRect), 'not visible');
+            assert.equal(rect.height, elRect.height, 'min-height ok');
+            assert.isTrue(intersects(rect, fitRect), 'partially visible');
           });
         });
 
@@ -547,13 +548,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.height, 100, 'height ok');
           });
 
-          test('min-height is respected: element is hidden if does not have enough height', function() {
+          test('min-height is preserved: element is displayed even if partially', function() {
             parent.style.top = (elRect.height - 10 - parentRect.height) + 'px';
             el.verticalAlign = 'bottom';
             el.style.minHeight = elRect.height + 'px';
             el.refit();
             var rect = el.getBoundingClientRect();
-            assert.isFalse(intersects(rect, fitRect), 'not visible');
+            assert.equal(rect.height, elRect.height, 'min-height ok');
+            assert.isTrue(intersects(rect, fitRect), 'partially visible');
           });
         });
 
@@ -659,13 +661,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.isBelow(rect.width, elRect.width, 'width ok');
           });
 
-          test('min-width is respected: element is hidden if does not have enough width', function() {
+          test('min-width is preserved: element is displayed even if partially', function() {
             parent.style.left = '-10px';
             el.style.minWidth = elRect.width + 'px';
             el.horizontalAlign = 'left';
             el.refit();
             var rect = el.getBoundingClientRect();
-            assert.isFalse(intersects(rect, fitRect), 'not visible');
+            assert.equal(rect.width, elRect.width, 'min-width ok');
+            assert.isTrue(intersects(rect, fitRect), 'partially visible');
           });
         });
 
@@ -723,13 +726,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.width, 100, 'width ok');
           });
 
-          test('min-width is respected: element is hidden if does not have enough width', function() {
+          test('min-width is preserved: element is displayed even if partially', function() {
             parent.style.left = (elRect.width - 10 - parentRect.width) + 'px';
             el.horizontalAlign = 'right';
             el.style.minWidth = elRect.width + 'px';
             el.refit();
             var rect = el.getBoundingClientRect();
-            assert.isFalse(intersects(rect, fitRect), 'not visible');
+            assert.equal(rect.width, elRect.width, 'min-width ok');
+            assert.isTrue(intersects(rect, fitRect), 'partially visible');
           });
 
         });


### PR DESCRIPTION
Fixes #44 by pushing the element beyond the viewport just to keep the min-width/min-height. Like this, at least a partial part is still visible.
Also, assue `null` to be `"auto"`; like this it will be enough to just set `horizontalAlign="auto"` to have also `verticalAlign` treated as `"auto"`.