### PR TITLE
dynamicAlign property

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -62,6 +62,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           min-width: 100px;
           min-height: 100px;
         }
+
+        button {
+          background-color: white;
+          border-radius: 5px;
+          border-width: 1px;
+        }
+        
+        button.selected {
+          background-color: #b3e5fc;
+        }
       </style>
       <template is="dom-bind">
         <template is="dom-repeat" items="[[containers]]">
@@ -81,7 +91,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <button on-tap="updateAlign" horizontal-align="auto">auto</button>
             <button on-tap="updateAlign" horizontal-align>null</button>
           </p>
-          <button on-tap="toggleNoOverlap">Toggle overlap</button>
+          <button on-tap="toggleNoOverlap">no overlap</button>
+          <button on-tap="toggleDynamicAlign">dynamic align</button>
         </simple-fit>
         <script>
           var defaultTarget = Polymer.dom(myFit).parentNode;
@@ -111,21 +122,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var target = Polymer.dom(e).rootTarget;
             if (target.hasAttribute('horizontal-align')) {
               myFit.horizontalAlign = target.getAttribute('horizontal-align');
+              var children = target.parentNode.querySelectorAll('[horizontal-align]');
+              for (var i = 0; i < children.length; i++) {
+                toggleClass(children[i], 'selected', children[i] === target);
+              }
             }
             if (target.hasAttribute('vertical-align')) {
               myFit.verticalAlign = target.getAttribute('vertical-align');
+              var children = target.parentNode.querySelectorAll('[vertical-align]');
+              for (var i = 0; i < children.length; i++) {
+                toggleClass(children[i], 'selected', children[i] === target);
+              }
             }
             template.refit();
           };
 
-          template.toggleNoOverlap = function() {
+          template.toggleNoOverlap = function(e) {
             myFit.noOverlap = !myFit.noOverlap;
+            toggleClass(Polymer.dom(e).rootTarget, 'selected', myFit.noOverlap);
+            template.refit();
+          };
+
+          template.toggleDynamicAlign = function(e) {
+            myFit.dynamicAlign = !myFit.dynamicAlign;
+            toggleClass(Polymer.dom(e).rootTarget, 'selected', myFit.dynamicAlign);
             template.refit();
           };
 
           // Listen for resize and scroll on window.
           window.addEventListener('resize', template.refit);
           window.addEventListener('scroll', template.refit);
+
+          function toggleClass(element, cssClass, condition) {
+            element.classList[condition ? 'add' : 'remove'](cssClass);
+          }
         </script>
       </template>
     </template>

--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -105,6 +105,14 @@ Use `noOverlap` to position the element around another element without overlappi
       },
 
       /**
+       * If true, it will use `horizontalAlign` and `verticalAlign` values as preferred alignment
+       * and if there's not enough space, it will pick the values which minimize the cropping.
+       */
+      dynamicAlign: {
+        type: Boolean
+      },
+
+      /**
        * The same as setting margin-left and margin-right css properties.
        * @deprecated
        */
@@ -338,42 +346,17 @@ Use `noOverlap` to position the element around another element without overlappi
       var margin = this._fitInfo.margin;
 
       // Consider the margin as part of the size for position calculations.
-      var width = rect.width + margin.left + margin.right;
-      var height = rect.height + margin.top + margin.bottom;
+      var size = {
+        width: rect.width + margin.left + margin.right,
+        height: rect.height + margin.top + margin.bottom
+      };
 
-      var alignRight = this.__isAlignRight(this._localeHorizontalAlign, width, positionRect, fitRect);
-      var alignBottom = this.__isAlignBottom(this.verticalAlign, height, positionRect, fitRect);
+      var position = this.__getPosition(this._localeHorizontalAlign, this.verticalAlign, size, positionRect, fitRect);
 
-      var top = alignBottom ? positionRect.bottom - height : positionRect.top;
-      var left = alignRight ? positionRect.right - width : positionRect.left;
+      var left = position.left + margin.left;
+      var top = position.top + margin.top;
 
-      if (this.noOverlap) {
-        // We can overlap one of the dimensions, choose the one that minimizes the cropped area.
-        var noOverlapLeft = left + positionRect.width * (alignRight ? -1 : 1);
-        var noOverlapTop = top + positionRect.height * (alignBottom ? -1 : 1);
-        var areaOverlapLeft = this.__getCroppedArea({
-          top: noOverlapTop,
-          left: left,
-          width: width,
-          height: height
-        }, fitRect);
-        var areaOverlapTop = this.__getCroppedArea({
-          top: top,
-          left: noOverlapLeft,
-          width: width,
-          height: height
-        }, fitRect);
-        if (areaOverlapLeft >= areaOverlapTop) {
-          left = noOverlapLeft;
-        } else {
-          top = noOverlapTop;
-        }
-      }
-
-      left += margin.left;
-      top += margin.top;
-
-      // Use original size (without margin)
+      // Use original size (without margin).
       var right = Math.min(fitRect.right - margin.right, left + rect.width);
       var bottom = Math.min(fitRect.bottom - margin.bottom, top + rect.height);
 
@@ -505,40 +488,159 @@ Use `noOverlap` to position the element around another element without overlappi
       return target.getBoundingClientRect();
     },
 
-    __isAlignRight: function(hAlign, size, positionRect, fitRect) {
-      if (!hAlign || hAlign === 'auto') {
-        // We should align on the right if positionTarget is on the right of fitInto,
-        // or if we can overlap and aligning on the left would cause more cropping
-        // than aligning on the right.
-        var positionTargetCenter = positionRect.left + positionRect.width/2;
-        var fitIntoCenter = fitRect.left + fitRect.width/2;
-        var croppedLeft = Math.abs(Math.min(0, positionRect.left));
-        var croppedRight = Math.abs(Math.min(0, positionRect.right - size));
-        return positionTargetCenter > fitIntoCenter ||
-          (!this.noOverlap && croppedLeft > croppedRight);
-      }
-      return hAlign === 'right';
-    },
-
-    __isAlignBottom: function(vAlign, size, positionRect, fitRect) {
-      if (!vAlign || vAlign === 'auto') {
-        // We should align on the bottom if positionTarget is on the bottom of fitInto,
-        // or if we can overlap and aligning on the top would cause more cropping
-        // than aligning on the bottom.
-        var positionTargetCenter = positionRect.top + positionRect.height/2;
-        var fitIntoCenter = fitRect.top + fitRect.height/2;
-        var croppedTop = Math.abs(Math.min(0, positionRect.top));
-        var croppedBottom = Math.abs(Math.min(0, positionRect.bottom - size));
-        return positionTargetCenter > fitIntoCenter ||
-          (!this.noOverlap && croppedTop > croppedBottom);
-      }
-      return vAlign === 'bottom';
-    },
-
     __getCroppedArea: function(rect, fitRect) {
       var verticalCrop = Math.min(0, rect.top) + Math.min(0, fitRect.bottom - (rect.top + rect.height));
       var horizontalCrop = Math.min(0, rect.left) + Math.min(0, fitRect.right - (rect.left + rect.width));
       return Math.abs(verticalCrop) * rect.width + Math.abs(horizontalCrop) * rect.height;
+    },
+
+
+    __getPosition: function(hAlign, vAlign, size, positionRect, fitRect) {
+      // All the possible configurations.
+      var positions = [{
+        verticalAlign: 'top',
+        horizontalAlign: 'left',
+        horizontalOverlap: true,
+        verticalOverlap: true,
+        top: positionRect.top,
+        left: positionRect.left
+      }, {
+        verticalAlign: 'top',
+        horizontalAlign: 'right',
+        horizontalOverlap: true,
+        verticalOverlap: true,
+        top: positionRect.top,
+        left: positionRect.right - size.width
+      }, {
+        verticalAlign: 'bottom',
+        horizontalAlign: 'left',
+        horizontalOverlap: true,
+        verticalOverlap: true,
+        top: positionRect.bottom - size.height,
+        left: positionRect.left
+      }, {
+        verticalAlign: 'bottom',
+        horizontalAlign: 'right',
+        horizontalOverlap: true,
+        verticalOverlap: true,
+        top: positionRect.bottom - size.height,
+        left: positionRect.right - size.width
+      }, {
+        verticalAlign: 'top',
+        horizontalAlign: 'left',
+        horizontalOverlap: false,
+        verticalOverlap: true,
+        top: positionRect.top,
+        left: positionRect.right
+      }, {
+        verticalAlign: 'top',
+        horizontalAlign: 'left',
+        horizontalOverlap: true,
+        verticalOverlap: false,
+        top: positionRect.bottom,
+        left: positionRect.left
+      }, {
+        verticalAlign: 'top',
+        horizontalAlign: 'right',
+        horizontalOverlap: false,
+        verticalOverlap: true,
+        top: positionRect.top,
+        left: positionRect.left - size.width
+      }, {
+        verticalAlign: 'top',
+        horizontalAlign: 'right',
+        horizontalOverlap: true,
+        verticalOverlap: false,
+        top: positionRect.bottom,
+        left: positionRect.right - size.width
+      }, {
+        verticalAlign: 'bottom',
+        horizontalAlign: 'left',
+        horizontalOverlap: true,
+        verticalOverlap: false,
+        top: positionRect.top - size.height,
+        left: positionRect.left
+      }, {
+        verticalAlign: 'bottom',
+        horizontalAlign: 'left',
+        horizontalOverlap: false,
+        verticalOverlap: true,
+        top: positionRect.bottom - size.height,
+        left: positionRect.right
+      }, {
+        verticalAlign: 'bottom',
+        horizontalAlign: 'right',
+        horizontalOverlap: true,
+        verticalOverlap: false,
+        top: positionRect.top - size.height,
+        left: positionRect.right - size.width
+      }, {
+        verticalAlign: 'bottom',
+        horizontalAlign: 'right',
+        horizontalOverlap: false,
+        verticalOverlap: true,
+        top: positionRect.bottom - size.height,
+        left: positionRect.left - size.width
+      }];
+
+      // Consider null as auto for coding convenience.
+      vAlign = vAlign === 'auto' ? null : vAlign;
+      hAlign = hAlign === 'auto' ? null : hAlign;
+
+      // Filter according to noOverlap, dynamicAlign, hAlign & vAlign
+      positions = positions.filter(function(pos) {
+        // If no overlap, at least one dimension should not overlap.
+        var res = this.noOverlap && (!pos.horizontalOverlap || !pos.verticalOverlap);
+        // Else if can overlap, both dimensions should be overlapped.
+        res = res || !this.noOverlap && pos.horizontalOverlap && pos.verticalOverlap;
+        // If dynamicAlign, we must consider all possible values, otherwise filter
+        // also by vertical/horizontal align.
+        if (res && !this.dynamicAlign) {
+          if (vAlign) {
+            res = res && pos.verticalAlign === vAlign;
+          }
+          if (hAlign) {
+            res = res && pos.horizontalAlign === hAlign;
+          }
+        }
+        // While at it, calculate the croppedArea.
+        if (res) {
+          pos.croppedArea = this.__getCroppedArea({
+            top: pos.top,
+            left: pos.left,
+            width: size.width,
+            height: size.height
+          }, fitRect);
+        }
+        return res;
+      }, this);
+
+      // Sort by cropped area, top positions crop less.
+      positions.sort(function(a, b) {
+        return a.croppedArea - b.croppedArea;
+      });
+
+      var result = positions[0];
+      if (this.dynamicAlign && (vAlign || hAlign)) {
+        // Try to get the one desired by the user!
+        var exactMatch;
+        for (var i = 0; i < positions.length; i++) {
+          var pos = positions[i];
+          if (pos.verticalAlign === vAlign || pos.horizontalAlign === hAlign) {
+            if (pos.croppedArea <= result.croppedArea) {
+              result = pos;
+            }
+            if (pos.verticalAlign === vAlign && pos.horizontalAlign === hAlign) {
+              exactMatch = pos;
+            }
+          }
+        }
+        // Exact match should always prevail.
+        if (exactMatch && exactMatch.croppedArea === result.croppedArea) {
+          result = exactMatch;
+        }
+      }
+      return result;
     }
 
   };

--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -488,10 +488,10 @@ Use `noOverlap` to position the element around another element without overlappi
       return target.getBoundingClientRect();
     },
 
-    __getCroppedArea: function(rect, fitRect) {
-      var verticalCrop = Math.min(0, rect.top) + Math.min(0, fitRect.bottom - (rect.top + rect.height));
-      var horizontalCrop = Math.min(0, rect.left) + Math.min(0, fitRect.right - (rect.left + rect.width));
-      return Math.abs(verticalCrop) * rect.width + Math.abs(horizontalCrop) * rect.height;
+    __getCroppedArea: function(position, size, fitRect) {
+      var verticalCrop = Math.min(0, position.top) + Math.min(0, fitRect.bottom - (position.top + size.height));
+      var horizontalCrop = Math.min(0, position.left) + Math.min(0, fitRect.right - (position.left + size.width));
+      return Math.abs(verticalCrop) * size.width + Math.abs(horizontalCrop) * size.height;
     },
 
 
@@ -548,28 +548,25 @@ Use `noOverlap` to position the element around another element without overlappi
         }, this);
       }
 
-      // Sort by cropped area, top positions crop less.
-      positions.sort(function(a, b) {
-        a.croppedArea = a.croppedArea || this.__getCroppedArea({ top: a.top, left: a.left, width: size.width, height: size.height }, fitRect);
-        b.croppedArea = b.croppedArea || this.__getCroppedArea({ top: b.top, left: b.left, width: size.width, height: size.height }, fitRect);
-        var diff = a.croppedArea - b.croppedArea;
-        // If they're the same, check align preferences.
-        if (diff === 0) {
-          // Check first exact match, the if hAlign or vAlign matches.
-          if (a.verticalAlign === vAlign && a.horizontalAlign === hAlign) {
-            diff = -1;
-          } else if (b.verticalAlign === vAlign && b.horizontalAlign === hAlign) {
-            diff = 1;
-          } else if (a.verticalAlign === vAlign || a.horizontalAlign === hAlign) {
-            diff = -1;
-          } else if (b.verticalAlign === vAlign || b.horizontalAlign === hAlign) {
-            diff = 1;
+      var position = positions[0];
+      if (positions.length > 1) {
+        // Search for position that crops less.
+        position.croppedArea = this.__getCroppedArea(position, size, fitRect);
+        for (var i = 1; i < positions.length; i++) {
+          var pos = positions[i];
+          pos.croppedArea = this.__getCroppedArea(pos, size, fitRect);
+          var diff = pos.croppedArea - position.croppedArea;
+          if (diff < 0) {
+            position = pos;
+          } else if (diff === 0 && (vAlign || hAlign)) {
+            if ((!vAlign || pos.verticalAlign === vAlign) && (!hAlign || pos.horizontalAlign === hAlign)) {
+              position = pos;
+            }
           }
         }
-        return diff;
-      }.bind(this));
+      }
 
-      return positions[0];
+      return position;
     }
 
   };

--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -537,32 +537,43 @@ Use `noOverlap` to position the element around another element without overlappi
         positions[5].left = positions[7].left -= positionRect.width;
       }
 
-      // Consider null as auto for coding convenience.
+      // Consider auto as null for coding convenience.
       vAlign = vAlign === 'auto' ? null : vAlign;
       hAlign = hAlign === 'auto' ? null : hAlign;
 
-      // If dynamicAlign, we must consider all possible values, otherwise filter by hAlign & vAlign.
-      if (!this.dynamicAlign && (vAlign || hAlign)) {
-        positions = positions.filter(function(pos) {
-          return (!vAlign || pos.verticalAlign === vAlign) && (!hAlign || pos.horizontalAlign === hAlign);
-        }, this);
-      }
+      var position;
+      for (var i = 0; i < positions.length; i++) {
+        var pos = positions[i];
+        // Align is ok if:
+        // - Horizontal AND vertical are required and match, or
+        // - Only vertical is required and matches, or
+        // - Only horizontal is required and matches.
+        var alignOk = (pos.verticalAlign === vAlign && pos.horizontalAlign === hAlign) ||
+                      (pos.verticalAlign === vAlign && !hAlign) ||
+                      (pos.horizontalAlign === hAlign && !vAlign);
 
-      var position = positions[0];
-      if (positions.length > 1) {
-        // Search for position that crops less.
-        position.croppedArea = this.__getCroppedArea(position, size, fitRect);
-        for (var i = 1; i < positions.length; i++) {
-          var pos = positions[i];
-          pos.croppedArea = this.__getCroppedArea(pos, size, fitRect);
-          var diff = pos.croppedArea - position.croppedArea;
-          if (diff < 0) {
-            position = pos;
-          } else if (diff === 0 && (vAlign || hAlign)) {
-            if ((!vAlign || pos.verticalAlign === vAlign) && (!hAlign || pos.horizontalAlign === hAlign)) {
-              position = pos;
-            }
-          }
+        // If both vAlign and hAlign are defined, return exact match.
+        // For dynamicAlign and noOverlap we'll have more than one candidate, so
+        // we'll have to check the croppedArea to make the best choice.
+        if (!this.dynamicAlign && !this.noOverlap && vAlign && hAlign && alignOk) {
+          position = pos;
+          break;
+        }
+
+        // Filter out elements that don't match the alignment (if defined).
+        // With dynamicAlign, we need to consider all the positions to find the
+        // one that minimizes the cropped area.
+        if (!this.dynamicAlign && (vAlign || hAlign) && !alignOk) {
+          continue;
+        }
+
+        position = position || pos;
+        pos.croppedArea = this.__getCroppedArea(pos, size, fitRect);
+        var diff = pos.croppedArea - position.croppedArea;
+        // Check which crops less. If it crops equally,
+        // check for alignment preferences.
+        if (diff < 0 || (diff === 0 && alignOk)) {
+          position = pos;
         }
       }
 

--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -530,11 +530,11 @@ Use `noOverlap` to position the element around another element without overlappi
           positions.push(copy);
         }
         // Horizontal overlap only.
-        positions[0].top = positions[1].top = positionRect.bottom;
-        positions[2].top = positions[3].top = positionRect.top - size.height;
+        positions[0].top = positions[1].top += positionRect.height;
+        positions[2].top = positions[3].top -= positionRect.height;
         // Vertical overlap only.
-        positions[4].left = positions[6].left = positionRect.right;
-        positions[5].left = positions[7].left = positionRect.left - size.width;
+        positions[4].left = positions[6].left += positionRect.width;
+        positions[5].left = positions[7].left -= positionRect.width;
       }
 
       // Consider null as auto for coding convenience.
@@ -544,7 +544,7 @@ Use `noOverlap` to position the element around another element without overlappi
       // If dynamicAlign, we must consider all possible values, otherwise filter by hAlign & vAlign.
       if (!this.dynamicAlign && (vAlign || hAlign)) {
         positions = positions.filter(function(pos) {
-          return pos.verticalAlign === vAlign || pos.horizontalAlign === hAlign;
+          return (!vAlign || pos.verticalAlign === vAlign) && (!hAlign || pos.horizontalAlign === hAlign);
         }, this);
       }
 

--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -497,150 +497,79 @@ Use `noOverlap` to position the element around another element without overlappi
 
     __getPosition: function(hAlign, vAlign, size, positionRect, fitRect) {
       // All the possible configurations.
+      // Ordered as top-left, top-right, bottom-left, bottom-right.
       var positions = [{
         verticalAlign: 'top',
         horizontalAlign: 'left',
-        horizontalOverlap: true,
-        verticalOverlap: true,
         top: positionRect.top,
         left: positionRect.left
       }, {
         verticalAlign: 'top',
         horizontalAlign: 'right',
-        horizontalOverlap: true,
-        verticalOverlap: true,
         top: positionRect.top,
         left: positionRect.right - size.width
       }, {
         verticalAlign: 'bottom',
         horizontalAlign: 'left',
-        horizontalOverlap: true,
-        verticalOverlap: true,
         top: positionRect.bottom - size.height,
         left: positionRect.left
       }, {
         verticalAlign: 'bottom',
         horizontalAlign: 'right',
-        horizontalOverlap: true,
-        verticalOverlap: true,
         top: positionRect.bottom - size.height,
         left: positionRect.right - size.width
-      }, {
-        verticalAlign: 'top',
-        horizontalAlign: 'left',
-        horizontalOverlap: false,
-        verticalOverlap: true,
-        top: positionRect.top,
-        left: positionRect.right
-      }, {
-        verticalAlign: 'top',
-        horizontalAlign: 'left',
-        horizontalOverlap: true,
-        verticalOverlap: false,
-        top: positionRect.bottom,
-        left: positionRect.left
-      }, {
-        verticalAlign: 'top',
-        horizontalAlign: 'right',
-        horizontalOverlap: false,
-        verticalOverlap: true,
-        top: positionRect.top,
-        left: positionRect.left - size.width
-      }, {
-        verticalAlign: 'top',
-        horizontalAlign: 'right',
-        horizontalOverlap: true,
-        verticalOverlap: false,
-        top: positionRect.bottom,
-        left: positionRect.right - size.width
-      }, {
-        verticalAlign: 'bottom',
-        horizontalAlign: 'left',
-        horizontalOverlap: true,
-        verticalOverlap: false,
-        top: positionRect.top - size.height,
-        left: positionRect.left
-      }, {
-        verticalAlign: 'bottom',
-        horizontalAlign: 'left',
-        horizontalOverlap: false,
-        verticalOverlap: true,
-        top: positionRect.bottom - size.height,
-        left: positionRect.right
-      }, {
-        verticalAlign: 'bottom',
-        horizontalAlign: 'right',
-        horizontalOverlap: true,
-        verticalOverlap: false,
-        top: positionRect.top - size.height,
-        left: positionRect.right - size.width
-      }, {
-        verticalAlign: 'bottom',
-        horizontalAlign: 'right',
-        horizontalOverlap: false,
-        verticalOverlap: true,
-        top: positionRect.bottom - size.height,
-        left: positionRect.left - size.width
       }];
+
+      if (this.noOverlap) {
+        // Duplicate.
+        for (var i = 0, l = positions.length; i < l; i++) {
+          var copy = {};
+          for (var key in positions[i]) {
+            copy[key] = positions[i][key];
+          }
+          positions.push(copy);
+        }
+        // Horizontal overlap only.
+        positions[0].top = positions[1].top = positionRect.bottom;
+        positions[2].top = positions[3].top = positionRect.top - size.height;
+        // Vertical overlap only.
+        positions[4].left = positions[6].left = positionRect.right;
+        positions[5].left = positions[7].left = positionRect.left - size.width;
+      }
 
       // Consider null as auto for coding convenience.
       vAlign = vAlign === 'auto' ? null : vAlign;
       hAlign = hAlign === 'auto' ? null : hAlign;
 
-      // Filter according to noOverlap, dynamicAlign, hAlign & vAlign
-      positions = positions.filter(function(pos) {
-        // If no overlap, at least one dimension should not overlap.
-        var res = this.noOverlap && (!pos.horizontalOverlap || !pos.verticalOverlap);
-        // Else if can overlap, both dimensions should be overlapped.
-        res = res || !this.noOverlap && pos.horizontalOverlap && pos.verticalOverlap;
-        // If dynamicAlign, we must consider all possible values, otherwise filter
-        // also by vertical/horizontal align.
-        if (res && !this.dynamicAlign) {
-          if (vAlign) {
-            res = res && pos.verticalAlign === vAlign;
-          }
-          if (hAlign) {
-            res = res && pos.horizontalAlign === hAlign;
-          }
-        }
-        // While at it, calculate the croppedArea.
-        if (res) {
-          pos.croppedArea = this.__getCroppedArea({
-            top: pos.top,
-            left: pos.left,
-            width: size.width,
-            height: size.height
-          }, fitRect);
-        }
-        return res;
-      }, this);
+      // If dynamicAlign, we must consider all possible values, otherwise filter by hAlign & vAlign.
+      if (!this.dynamicAlign && (vAlign || hAlign)) {
+        positions = positions.filter(function(pos) {
+          return pos.verticalAlign === vAlign || pos.horizontalAlign === hAlign;
+        }, this);
+      }
 
       // Sort by cropped area, top positions crop less.
       positions.sort(function(a, b) {
-        return a.croppedArea - b.croppedArea;
-      });
-
-      var result = positions[0];
-      if (this.dynamicAlign && (vAlign || hAlign)) {
-        // Try to get the one desired by the user!
-        var exactMatch;
-        for (var i = 0; i < positions.length; i++) {
-          var pos = positions[i];
-          if (pos.verticalAlign === vAlign || pos.horizontalAlign === hAlign) {
-            if (pos.croppedArea <= result.croppedArea) {
-              result = pos;
-            }
-            if (pos.verticalAlign === vAlign && pos.horizontalAlign === hAlign) {
-              exactMatch = pos;
-            }
+        a.croppedArea = a.croppedArea || this.__getCroppedArea({ top: a.top, left: a.left, width: size.width, height: size.height }, fitRect);
+        b.croppedArea = b.croppedArea || this.__getCroppedArea({ top: b.top, left: b.left, width: size.width, height: size.height }, fitRect);
+        var diff = a.croppedArea - b.croppedArea;
+        // If they're the same, check align preferences.
+        if (diff === 0) {
+          // Check first exact match, the if hAlign or vAlign matches.
+          if (a.verticalAlign === vAlign && a.horizontalAlign === hAlign) {
+            diff = -1;
+          } else if (b.verticalAlign === vAlign && b.horizontalAlign === hAlign) {
+            diff = 1;
+          } else if (a.verticalAlign === vAlign || a.horizontalAlign === hAlign) {
+            diff = -1;
+          } else if (b.verticalAlign === vAlign || b.horizontalAlign === hAlign) {
+            diff = 1;
           }
         }
-        // Exact match should always prevail.
-        if (exactMatch && exactMatch.croppedArea === result.croppedArea) {
-          result = exactMatch;
-        }
-      }
-      return result;
+        return diff;
+      }.bind(this));
+
+      return positions[0];
     }
 
   };

--- a/test/iron-fit-behavior.html
+++ b/test/iron-fit-behavior.html
@@ -495,6 +495,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.height, elRect.height, 'min-height ok');
             assert.isTrue(intersects(rect, fitRect), 'partially visible');
           });
+
+          test('dynamicAlign will prefer bottom align if it minimizes the cropping', function() {
+            parent.style.top = '-10px';
+            parentRect = parent.getBoundingClientRect();
+            el.verticalAlign = 'top';
+            el.dynamicAlign = true;
+            el.refit();
+            var rect = el.getBoundingClientRect();
+            assert.equal(rect.bottom, parentRect.bottom, 'bottom ok');
+            assert.equal(rect.height, elRect.height, 'no cropping');
+          });
         });
 
         suite('when verticalAlign is bottom', function() {
@@ -556,6 +567,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var rect = el.getBoundingClientRect();
             assert.equal(rect.height, elRect.height, 'min-height ok');
             assert.isTrue(intersects(rect, fitRect), 'partially visible');
+          });
+
+          test('dynamicAlign will prefer top align if it minimizes the cropping', function() {
+            parent.style.top = (window.innerHeight - elRect.height) + 'px';
+            parentRect = parent.getBoundingClientRect();
+            el.verticalAlign = 'bottom';
+            el.dynamicAlign = true;
+            el.refit();
+            var rect = el.getBoundingClientRect();
+            assert.equal(rect.top, parentRect.top, 'top ok');
+            assert.equal(rect.height, elRect.height, 'no cropping');
           });
         });
 
@@ -670,6 +692,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.width, elRect.width, 'min-width ok');
             assert.isTrue(intersects(rect, fitRect), 'partially visible');
           });
+
+          test('dynamicAlign will prefer right align if it minimizes the cropping', function() {
+            parent.style.left = '-10px';
+            parentRect = parent.getBoundingClientRect();
+            el.horizontalAlign = 'left';
+            el.dynamicAlign = true;
+            el.refit();
+            var rect = el.getBoundingClientRect();
+            assert.equal(rect.right, parentRect.right, 'right ok');
+            assert.equal(rect.height, elRect.height, 'no cropping');
+          });
+
         });
 
         suite('when horizontalAlign is right', function() {
@@ -734,6 +768,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var rect = el.getBoundingClientRect();
             assert.equal(rect.width, elRect.width, 'min-width ok');
             assert.isTrue(intersects(rect, fitRect), 'partially visible');
+          });
+
+          test('dynamicAlign will prefer left align if it minimizes the cropping', function() {
+            parent.style.left = (window.innerWidth - elRect.width) + 'px';
+            parentRect = parent.getBoundingClientRect();
+            el.horizontalAlign = 'right';
+            el.dynamicAlign = true;
+            el.refit();
+            var rect = el.getBoundingClientRect();
+            assert.equal(rect.left, parentRect.left, 'left ok');
+            assert.equal(rect.height, elRect.height, 'no cropping');
           });
 
         });


### PR DESCRIPTION
Fixes #45 by introducing `dynamicAlign` boolean. 
Changed the internal logic with which we choose what is the "best" position, which should be much cleaner & predictable (see `__getPosition`).

(rebased on top of https://github.com/PolymerElements/iron-fit-behavior/pull/46, see last commit only)