### PR TITLE
prefer vertical over horizontal overlap

### DIFF
--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -544,36 +544,40 @@ Use `noOverlap` to position the element around another element without overlappi
       var position;
       for (var i = 0; i < positions.length; i++) {
         var pos = positions[i];
-        // Align is ok if:
-        // - Horizontal AND vertical are required and match, or
-        // - Only vertical is required and matches, or
-        // - Only horizontal is required and matches.
-        var alignOk = (pos.verticalAlign === vAlign && pos.horizontalAlign === hAlign) ||
-                      (pos.verticalAlign === vAlign && !hAlign) ||
-                      (pos.horizontalAlign === hAlign && !vAlign);
 
         // If both vAlign and hAlign are defined, return exact match.
         // For dynamicAlign and noOverlap we'll have more than one candidate, so
         // we'll have to check the croppedArea to make the best choice.
-        if (!this.dynamicAlign && !this.noOverlap && vAlign && hAlign && alignOk) {
+        if (!this.dynamicAlign && !this.noOverlap &&
+            pos.verticalAlign === vAlign && pos.horizontalAlign === hAlign) {
           position = pos;
           break;
         }
 
+        // Align is ok if alignment preferences are respected. If no preferences,
+        // it is considered ok.
+        var alignOk = (!vAlign || pos.verticalAlign === vAlign) &&
+                      (!hAlign || pos.horizontalAlign === hAlign);
+
         // Filter out elements that don't match the alignment (if defined).
         // With dynamicAlign, we need to consider all the positions to find the
         // one that minimizes the cropped area.
-        if (!this.dynamicAlign && (vAlign || hAlign) && !alignOk) {
+        if (!this.dynamicAlign && !alignOk) {
           continue;
         }
 
         position = position || pos;
         pos.croppedArea = this.__getCroppedArea(pos, size, fitRect);
         var diff = pos.croppedArea - position.croppedArea;
-        // Check which crops less. If it crops equally,
-        // check for alignment preferences.
+        // Check which crops less. If it crops equally, check if align is ok.
         if (diff < 0 || (diff === 0 && alignOk)) {
           position = pos;
+        }
+        // If not cropped and respects the align requirements, keep it.
+        // This allows to prefer positions overlapping horizontally over the
+        // ones overlapping vertically.
+        if (position.croppedArea === 0 && alignOk) {
+          break;
         }
       }
 

--- a/test/iron-fit-behavior.html
+++ b/test/iron-fit-behavior.html
@@ -827,6 +827,55 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.width, elRect.width, 'no cropping');
             assert.isFalse(intersects(rect, parentRect), 'no overlap');
           });
+        });
+
+        suite('prefer horizontal overlap to vertical overlap', function() {
+          setup(function() {
+            el.noOverlap = true;
+            el.dynamicAlign = true;
+            // Make space around the positionTarget.
+            parent.style.top = elRect.height + 'px';
+            parent.style.left = elRect.width + 'px';
+            parent.style.width = '10px';
+            parent.style.height = '10px';
+            parentRect = parent.getBoundingClientRect();
+          });
+
+          test('top-left aligns to target bottom-left', function() {
+            el.verticalAlign = 'top';
+            el.horizontalAlign = 'left';
+            el.refit();
+            var rect = el.getBoundingClientRect();
+            assert.equal(rect.left, parentRect.left, 'left ok');
+            assert.equal(rect.top, parentRect.bottom, 'top ok');
+          });
+
+          test('top-right aligns to target bottom-right', function() {
+            el.verticalAlign = 'top';
+            el.horizontalAlign = 'right';
+            el.refit();
+            var rect = el.getBoundingClientRect();
+            assert.equal(rect.right, parentRect.right, 'right ok');
+            assert.equal(rect.top, parentRect.bottom, 'top ok');
+          });
+
+          test('bottom-left aligns to target top-left', function() {
+            el.verticalAlign = 'bottom';
+            el.horizontalAlign = 'left';
+            el.refit();
+            var rect = el.getBoundingClientRect();
+            assert.equal(rect.left, parentRect.left, 'left ok');
+            assert.equal(rect.bottom, parentRect.top, 'bottom ok');
+          });
+
+          test('bottom-right aligns to target top-right', function() {
+            el.verticalAlign = 'bottom';
+            el.horizontalAlign = 'right';
+            el.refit();
+            var rect = el.getBoundingClientRect();
+            assert.equal(rect.right, parentRect.right, 'right ok');
+            assert.equal(rect.bottom, parentRect.top, 'bottom ok');
+          });
 
         });
 


### PR DESCRIPTION
When given the choice between overlapping horizontally or vertically, `iron-fit-behavior` now chooses to first try with vertical overlap, and then check horizontal overlap.
In this way, in the cases where there's enough space for both options, the element will be positioned like [1] instead of like [2].

[1]
![screen shot 2016-05-09 at 6 38 08 pm](https://cloud.githubusercontent.com/assets/6173664/15133162/5317a064-1615-11e6-8515-b094911ea8a0.png)


[2]
![screen shot 2016-05-09 at 6 38 55 pm](https://cloud.githubusercontent.com/assets/6173664/15133165/57d57496-1615-11e6-9949-7442aab310c2.png)