### PR TITLE
preserve scroll position on refit

### DIFF
--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -317,10 +317,15 @@ Use `noOverlap` to position the element around another element without overlappi
      * Equivalent to calling `resetFit()` and `fit()`. Useful to call this after
      * the element or the `fitInto` element has been resized, or if any of the
      * positioning properties (e.g. `horizontalAlign, verticalAlign`) is updated.
+     * It preserves the scroll position of the sizingTarget.
      */
     refit: function() {
+      var scrollLeft = this.sizingTarget.scrollLeft;
+      var scrollTop = this.sizingTarget.scrollTop;
       this.resetFit();
       this.fit();
+      this.sizingTarget.scrollLeft = scrollLeft;
+      this.sizingTarget.scrollTop = scrollTop;
     },
 
     /**

--- a/test/iron-fit-behavior.html
+++ b/test/iron-fit-behavior.html
@@ -88,6 +88,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         box-sizing: border-box;
       }
 
+      .sizer {
+        width: 9999px;
+        height: 9999px;
+      }
+
     </style>
 
   </head>
@@ -167,6 +172,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             </div>
           </test-fit>
         </div>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="scrollable">
+      <template>
+        <test-fit auto-fit-on-attach class="scrolling">
+          scrollable
+          <div class="sizer"></div>
+        </test-fit>
       </template>
     </test-fixture>
 
@@ -360,6 +374,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           el.refit();
           var rect = el.getBoundingClientRect();
           assert.isTrue(rect.height <= window.innerHeight, 'height is less than or equal to viewport height');
+        });
+
+        test('scrolling sizingTarget preserves scrolling position', function() {
+          el = fixture('scrollable');
+          el.scrollTop = 20;
+          el.scrollLeft = 20;
+          el.refit();
+          assert.equal(el.scrollTop, 20, 'scrollTop ok');
+          assert.equal(el.scrollLeft, 20, 'scrollLeft ok');
         });
 
       });


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-dialog-behavior/issues/73.
It will preserve the scroll position of the sizingTarget on refit.