### PR TITLE
suppress internally used, deprecated offset properties

### DIFF
--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -243,6 +243,7 @@ Use `noOverlap` to position the element around another element without overlappi
 
     /**
      * Memoize information needed to position and size the target element.
+     * @suppress {deprecated}
      */
     _discoverInfo: function() {
       if (this._fitInfo) {


### PR DESCRIPTION
/cc @valdrinkoshi @rictic 

this solves the last issue in Chrome being able to closure compile `PaperDialogBehavior` and dependencies