### PR TITLE
discover info in position, constrain, center

### DIFF
--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -235,7 +235,6 @@ Use `noOverlap` to position the element around another element without overlappi
      * Positions and fits the element into the `fitInto` element.
      */
     fit: function() {
-      this._discoverInfo();
       this.position();
       this.constrain();
       this.center();
@@ -337,6 +336,7 @@ Use `noOverlap` to position the element around another element without overlappi
         // needs to be centered, and it is done after constrain.
         return;
       }
+      this._discoverInfo();
 
       this.style.position = 'fixed';
       // Need border-box for margin/padding.
@@ -397,6 +397,8 @@ Use `noOverlap` to position the element around another element without overlappi
       if (this.horizontalAlign || this.verticalAlign) {
         return;
       }
+      this._discoverInfo();
+
       var info = this._fitInfo;
       // position at (0px, 0px) if not already positioned, so we can measure the natural size.
       if (!info.positionedBy.vertically) {
@@ -451,6 +453,8 @@ Use `noOverlap` to position the element around another element without overlappi
       if (this.horizontalAlign || this.verticalAlign) {
         return;
       }
+      this._discoverInfo();
+
       var positionedBy = this._fitInfo.positionedBy;
       if (positionedBy.vertically && positionedBy.horizontally) {
         // Already positioned.

--- a/test/iron-fit-behavior.html
+++ b/test/iron-fit-behavior.html
@@ -100,6 +100,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <div class="constrain"></div>
 
+    <test-fixture id="basic">
+      <template>
+        <test-fit>
+          Basic
+        </test-fit>
+      </template>
+    </test-fixture>
+
     <test-fixture id="absolute">
       <template>
         <test-fit auto-fit-on-attach class="absolute">
@@ -201,6 +209,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       function intersects(r1, r2) {
         return !(r2.left >= r1.right || r2.right <= r1.left || r2.top >= r1.bottom || r2.bottom <= r1.top);
       }
+
+      suite('basic', function() {
+
+        var el;
+        setup(function() {
+          el = fixture('basic');
+        });
+
+        test('position() works without autoFitOnAttach', function() {
+          el.verticalAlign = 'top';
+          el.horizontalAlign = 'left';
+          el.position();
+          var rect = el.getBoundingClientRect();
+          assert.equal(rect.top, 0, 'top ok');
+          assert.equal(rect.left, 0, 'left ok');
+        });
+
+        test('constrain() works without autoFitOnAttach', function() {
+          el.constrain();
+          var style = getComputedStyle(el);
+          assert.equal(style.maxWidth, window.innerWidth + 'px', 'maxWidth ok');
+          assert.equal(style.maxHeight, window.innerHeight + 'px', 'maxHeight ok');
+        });
+
+        test('center() works without autoFitOnAttach', function() {
+          el.center();
+          var rect = el.getBoundingClientRect();
+          assert.closeTo(rect.left - (window.innerWidth - rect.right), 0, 5, 'centered horizontally');
+          assert.closeTo(rect.top - (window.innerHeight - rect.bottom), 0, 5, 'centered vertically');
+        });
+
+      });
 
       suite('manual positioning', function() {
 


### PR DESCRIPTION
Fixes #57 by invoking `_discoverInfo` in `position(), constrain(), center()`. Like this, each of those methods can be safely invoked and rely on the existence of the `_fitInfo` object. Previously, it was relying on users calling `fit()`.