### PR TITLE
vertical and horizontal offset affect top and left, not margin

### DIFF
--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -365,19 +365,22 @@ Use `noOverlap` to position the element around another element without overlappi
 
       var position = this.__getPosition(this._localeHorizontalAlign, this.verticalAlign, size, positionRect, fitRect);
 
-      var minLeft = margin.left + (position.horizontalAlign === 'left' ? this.horizontalOffset : 0);
-      var minTop = margin.top + (position.verticalAlign === 'top' ? this.verticalOffset : 0);
-      var maxRight = fitRect.right - margin.right - (position.horizontalAlign === 'left' ? 0 : this.horizontalOffset);
-      var maxBottom = fitRect.bottom - margin.bottom - (position.verticalAlign === 'top' ? 0 : this.verticalOffset);
-
       var left = position.left + margin.left;
       var top = position.top + margin.top;
+
+      // We first limit right/bottom, then use those values to limit top/left.
+      var maxRight = fitRect.right - margin.right - this.horizontalOffset * (position.horizontalAlign !== 'left');
+      var maxBottom = fitRect.bottom - margin.bottom - this.verticalOffset * (position.verticalAlign !== 'top');
       var right = Math.min(maxRight, left + rect.width);
       var bottom = Math.min(maxBottom, top + rect.height);
 
+      // Keep left/top within fitInto and respect minWidth/minHeight.
+      var minLeft = margin.left + this.horizontalOffset * (position.horizontalAlign === 'left');
+      var minTop = margin.top + this.verticalOffset * (position.verticalAlign === 'top');
       left = Math.min(Math.max(left, minLeft), right - this._fitInfo.sizedBy.minWidth);
       top = Math.min(Math.max(top, minTop), bottom - this._fitInfo.sizedBy.minHeight);
 
+      // Use right/bottom to set maxWidth/maxHeight.
       this.sizingTarget.style.maxWidth = (right - left) + 'px';
       this.sizingTarget.style.maxHeight = (bottom - top) + 'px';
 

--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -355,9 +355,16 @@ Use `noOverlap` to position the element around another element without overlappi
       var positionRect = this.__getNormalizedRect(this.positionTarget);
       var fitRect = this.__getNormalizedRect(this.fitInto);
 
-      var position = this.__getPosition(this._localeHorizontalAlign, this.verticalAlign, rect, positionRect, fitRect);
-
       var margin = this._fitInfo.margin;
+
+      // Consider the margin as part of the size for position calculations.
+      var size = {
+        width: rect.width + margin.left + margin.right,
+        height: rect.height + margin.top + margin.bottom
+      };
+
+      var position = this.__getPosition(this._localeHorizontalAlign, this.verticalAlign, size, positionRect, fitRect);
+
       var minLeft = margin.left + (position.horizontalAlign === 'left' ? this.horizontalOffset : 0);
       var minTop = margin.top + (position.verticalAlign === 'top' ? this.verticalOffset : 0);
       var maxRight = fitRect.right - margin.right - (position.horizontalAlign === 'left' ? 0 : this.horizontalOffset);
@@ -491,13 +498,7 @@ Use `noOverlap` to position the element around another element without overlappi
     },
 
 
-    __getPosition: function(hAlign, vAlign, rect, positionRect, fitRect) {
-      var margin = this._fitInfo.margin;
-      // Consider the margin as part of the size for position calculations.
-      var size = {
-        width: rect.width + margin.left + margin.right,
-        height: rect.height + margin.top + margin.bottom
-      };
+    __getPosition: function(hAlign, vAlign, size, positionRect, fitRect) {
       // All the possible configurations.
       // Ordered as top-left, top-right, bottom-left, bottom-right.
       var positions = [{

--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -113,8 +113,18 @@ Use `noOverlap` to position the element around another element without overlappi
       },
 
       /**
-       * The same as setting margin-left and margin-right css properties.
-       * @deprecated
+       * A pixel value that will be added to the position calculated for the
+       * given `horizontalAlign`, in the direction of alignment. You can think
+       * of it as increasing or decreasing the distance to the side of the
+       * screen given by `horizontalAlign`.
+       *
+       * If `horizontalAlign` is "left", this offset will increase or decrease
+       * the distance to the left side of the screen: a negative offset will
+       * move the dropdown to the left; a positive one, to the right.
+       *
+       * Conversely if `horizontalAlign` is "right", this offset will increase
+       * or decrease the distance to the right side of the screen: a negative
+       * offset will move the dropdown to the right; a positive one, to the left.
        */
       horizontalOffset: {
         type: Number,
@@ -123,8 +133,18 @@ Use `noOverlap` to position the element around another element without overlappi
       },
 
       /**
-       * The same as setting margin-top and margin-bottom css properties.
-       * @deprecated
+       * A pixel value that will be added to the position calculated for the
+       * given `verticalAlign`, in the direction of alignment. You can think
+       * of it as increasing or decreasing the distance to the side of the
+       * screen given by `verticalAlign`.
+       *
+       * If `verticalAlign` is "top", this offset will increase or decrease
+       * the distance to the top side of the screen: a negative offset will
+       * move the dropdown upwards; a positive one, downwards.
+       *
+       * Conversely if `verticalAlign` is "bottom", this offset will increase
+       * or decrease the distance to the bottom side of the screen: a negative
+       * offset will move the dropdown downwards; a positive one, upwards.
        */
       verticalOffset: {
         type: Number,
@@ -282,20 +302,6 @@ Use `noOverlap` to position the element around another element without overlappi
           left: parseInt(target.marginLeft, 10) || 0
         }
       };
-
-      // Support these properties until they are removed.
-      if (this.verticalOffset) {
-        this._fitInfo.margin.top = this._fitInfo.margin.bottom = this.verticalOffset;
-        this._fitInfo.inlineStyle.marginTop = this.style.marginTop || '';
-        this._fitInfo.inlineStyle.marginBottom = this.style.marginBottom || '';
-        this.style.marginTop = this.style.marginBottom = this.verticalOffset + 'px';
-      }
-      if (this.horizontalOffset) {
-        this._fitInfo.margin.left = this._fitInfo.margin.right = this.horizontalOffset;
-        this._fitInfo.inlineStyle.marginLeft = this.style.marginLeft || '';
-        this._fitInfo.inlineStyle.marginRight = this.style.marginRight || '';
-        this.style.marginLeft = this.style.marginRight = this.horizontalOffset + 'px';
-      }
     },
 
     /**
@@ -349,37 +355,21 @@ Use `noOverlap` to position the element around another element without overlappi
       var positionRect = this.__getNormalizedRect(this.positionTarget);
       var fitRect = this.__getNormalizedRect(this.fitInto);
 
+      var position = this.__getPosition(this._localeHorizontalAlign, this.verticalAlign, rect, positionRect, fitRect);
+
       var margin = this._fitInfo.margin;
-
-      // Consider the margin as part of the size for position calculations.
-      var size = {
-        width: rect.width + margin.left + margin.right,
-        height: rect.height + margin.top + margin.bottom
-      };
-
-      var position = this.__getPosition(this._localeHorizontalAlign, this.verticalAlign, size, positionRect, fitRect);
+      var minLeft = margin.left + (position.horizontalAlign === 'left' ? this.horizontalOffset : 0);
+      var minTop = margin.top + (position.verticalAlign === 'top' ? this.verticalOffset : 0);
+      var maxRight = fitRect.right - margin.right - (position.horizontalAlign === 'left' ? 0 : this.horizontalOffset);
+      var maxBottom = fitRect.bottom - margin.bottom - (position.verticalAlign === 'top' ? 0 : this.verticalOffset);
 
       var left = position.left + margin.left;
       var top = position.top + margin.top;
+      var right = Math.min(maxRight, left + rect.width);
+      var bottom = Math.min(maxBottom, top + rect.height);
 
-      // Use original size (without margin).
-      var right = Math.min(fitRect.right - margin.right, left + rect.width);
-      var bottom = Math.min(fitRect.bottom - margin.bottom, top + rect.height);
-
-      var minWidth = this._fitInfo.sizedBy.minWidth;
-      var minHeight = this._fitInfo.sizedBy.minHeight;
-      if (left < margin.left) {
-        left = margin.left;
-        if (right - left < minWidth) {
-          left = right - minWidth;
-        }
-      }
-      if (top < margin.top) {
-        top = margin.top;
-        if (bottom - top < minHeight) {
-          top = bottom - minHeight;
-        }
-      }
+      left = Math.min(Math.max(left, minLeft), right - this._fitInfo.sizedBy.minWidth);
+      top = Math.min(Math.max(top, minTop), bottom - this._fitInfo.sizedBy.minHeight);
 
       this.sizingTarget.style.maxWidth = (right - left) + 'px';
       this.sizingTarget.style.maxHeight = (bottom - top) + 'px';
@@ -501,29 +491,35 @@ Use `noOverlap` to position the element around another element without overlappi
     },
 
 
-    __getPosition: function(hAlign, vAlign, size, positionRect, fitRect) {
+    __getPosition: function(hAlign, vAlign, rect, positionRect, fitRect) {
+      var margin = this._fitInfo.margin;
+      // Consider the margin as part of the size for position calculations.
+      var size = {
+        width: rect.width + margin.left + margin.right,
+        height: rect.height + margin.top + margin.bottom
+      };
       // All the possible configurations.
       // Ordered as top-left, top-right, bottom-left, bottom-right.
       var positions = [{
         verticalAlign: 'top',
         horizontalAlign: 'left',
-        top: positionRect.top,
-        left: positionRect.left
+        top: positionRect.top + this.verticalOffset,
+        left: positionRect.left + this.horizontalOffset
       }, {
         verticalAlign: 'top',
         horizontalAlign: 'right',
-        top: positionRect.top,
-        left: positionRect.right - size.width
+        top: positionRect.top + this.verticalOffset,
+        left: positionRect.right - size.width - this.horizontalOffset
       }, {
         verticalAlign: 'bottom',
         horizontalAlign: 'left',
-        top: positionRect.bottom - size.height,
-        left: positionRect.left
+        top: positionRect.bottom - size.height - this.verticalOffset,
+        left: positionRect.left + this.horizontalOffset
       }, {
         verticalAlign: 'bottom',
         horizontalAlign: 'right',
-        top: positionRect.bottom - size.height,
-        left: positionRect.right - size.width
+        top: positionRect.bottom - size.height - this.verticalOffset,
+        left: positionRect.right - size.width - this.horizontalOffset
       }];
 
       if (this.noOverlap) {

--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -43,6 +43,17 @@ Use `noOverlap` to position the element around another element without overlappi
         </iron-fit-impl>
       </div>
 
+Use `horizontalOffset, verticalOffset` to offset the element from its `positionTarget`;
+`Polymer.IronFitBehavior` will collapse these in order to keep the element
+within `fitInto` boundaries, while preserving the element's CSS margin values.
+
+      <div class="container">
+        <iron-fit-impl vertical-align="top" vertical-offset="20">
+          With vertical offset
+        </iron-fit-impl>
+      </div>
+
+
 @demo demo/index.html
 @polymerBehavior
 */
@@ -368,17 +379,16 @@ Use `noOverlap` to position the element around another element without overlappi
       var left = position.left + margin.left;
       var top = position.top + margin.top;
 
-      // We first limit right/bottom, then use those values to limit top/left.
-      var maxRight = fitRect.right - margin.right - this.horizontalOffset * (position.horizontalAlign !== 'left');
-      var maxBottom = fitRect.bottom - margin.bottom - this.verticalOffset * (position.verticalAlign !== 'top');
-      var right = Math.min(maxRight, left + rect.width);
-      var bottom = Math.min(maxBottom, top + rect.height);
+      // We first limit right/bottom within fitInto respecting the margin,
+      // then use those values to limit top/left.
+      var right = Math.min(fitRect.right - margin.right, left + rect.width);
+      var bottom = Math.min(fitRect.bottom - margin.bottom, top + rect.height);
 
-      // Keep left/top within fitInto.
-      var minLeft = fitRect.left + margin.left + this.horizontalOffset * (position.horizontalAlign === 'left');
-      var minTop = fitRect.top + margin.top + this.verticalOffset * (position.verticalAlign === 'top');
-      left = Math.max(minLeft, Math.min(left, right - this._fitInfo.sizedBy.minWidth));
-      top = Math.max(minTop, Math.min(top, bottom - this._fitInfo.sizedBy.minHeight));
+      // Keep left/top within fitInto respecting the margin.
+      left = Math.max(fitRect.left + margin.left,
+        Math.min(left, right - this._fitInfo.sizedBy.minWidth));
+      top = Math.max(fitRect.top + margin.top,
+        Math.min(top, bottom - this._fitInfo.sizedBy.minHeight));
 
       // Use right/bottom to set maxWidth/maxHeight, and respect minWidth/minHeight.
       this.sizingTarget.style.maxWidth = Math.max(right - left, this._fitInfo.sizedBy.minWidth) + 'px';

--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -375,8 +375,8 @@ Use `noOverlap` to position the element around another element without overlappi
       var bottom = Math.min(maxBottom, top + rect.height);
 
       // Keep left/top within fitInto and respect minWidth/minHeight.
-      var minLeft = margin.left + this.horizontalOffset * (position.horizontalAlign === 'left');
-      var minTop = margin.top + this.verticalOffset * (position.verticalAlign === 'top');
+      var minLeft = fitRect.left + margin.left + this.horizontalOffset * (position.horizontalAlign === 'left');
+      var minTop = fitRect.top + margin.top + this.verticalOffset * (position.verticalAlign === 'top');
       left = Math.min(Math.max(left, minLeft), right - this._fitInfo.sizedBy.minWidth);
       top = Math.min(Math.max(top, minTop), bottom - this._fitInfo.sizedBy.minHeight);
 

--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -374,15 +374,15 @@ Use `noOverlap` to position the element around another element without overlappi
       var right = Math.min(maxRight, left + rect.width);
       var bottom = Math.min(maxBottom, top + rect.height);
 
-      // Keep left/top within fitInto and respect minWidth/minHeight.
+      // Keep left/top within fitInto.
       var minLeft = fitRect.left + margin.left + this.horizontalOffset * (position.horizontalAlign === 'left');
       var minTop = fitRect.top + margin.top + this.verticalOffset * (position.verticalAlign === 'top');
-      left = Math.min(Math.max(left, minLeft), right - this._fitInfo.sizedBy.minWidth);
-      top = Math.min(Math.max(top, minTop), bottom - this._fitInfo.sizedBy.minHeight);
+      left = Math.max(minLeft, Math.min(left, right - this._fitInfo.sizedBy.minWidth));
+      top = Math.max(minTop, Math.min(top, bottom - this._fitInfo.sizedBy.minHeight));
 
-      // Use right/bottom to set maxWidth/maxHeight.
-      this.sizingTarget.style.maxWidth = (right - left) + 'px';
-      this.sizingTarget.style.maxHeight = (bottom - top) + 'px';
+      // Use right/bottom to set maxWidth/maxHeight, and respect minWidth/minHeight.
+      this.sizingTarget.style.maxWidth = Math.max(right - left, this._fitInfo.sizedBy.minWidth) + 'px';
+      this.sizingTarget.style.maxHeight = Math.max(bottom - top, this._fitInfo.sizedBy.minHeight) + 'px';
 
       // Remove the offset caused by any stacking context.
       this.style.left = (left - rect.left) + 'px';

--- a/test/iron-fit-behavior.html
+++ b/test/iron-fit-behavior.html
@@ -514,6 +514,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.height, elRect.height, 'no cropping');
           });
 
+          test('element is kept in viewport', function() {
+            el.verticalAlign = 'top';
+            // Make it go out of screen
+            el.verticalOffset = -1000;
+            el.refit();
+            var rect = el.getBoundingClientRect();
+            assert.equal(rect.top, 0, 'top in viewport');
+            assert.isTrue(rect.height < elRect.height, 'reduced size');
+          });
+
           test('negative verticalOffset does not crop element', function() {
             // Push to the bottom of the screen.
             parent.style.top = (window.innerHeight - 50) +'px';
@@ -597,6 +607,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var rect = el.getBoundingClientRect();
             assert.equal(rect.bottom, parentRect.bottom - 10, 'bottom ok');
             assert.equal(rect.height, elRect.height, 'no cropping');
+          });
+
+          test('element is kept in viewport', function() {
+            el.verticalAlign = 'bottom';
+            // Make it go out of screen
+            el.verticalOffset = 1000;
+            el.refit();
+            var rect = el.getBoundingClientRect();
+            assert.equal(rect.top, 0, 'top in viewport');
+            assert.isTrue(rect.height < elRect.height, 'reduced size');
           });
 
           test('element max-height is updated', function() {
@@ -724,6 +744,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.width, elRect.width, 'no cropping');
           });
 
+          test('element is kept in viewport', function() {
+            el.horizontalAlign = 'left';
+            // Make it go out of screen.
+            el.horizontalOffset = -1000;
+            el.refit();
+            var rect = el.getBoundingClientRect();
+            assert.equal(rect.left, 0, 'left in viewport');
+            assert.isTrue(rect.width < elRect.width, 'reduced size');
+          });
+
           test('negative horizontalOffset does not crop element', function() {
             // Push to the bottom of the screen.
             parent.style.left = (window.innerWidth - 50) +'px';
@@ -811,6 +841,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var rect = el.getBoundingClientRect();
             assert.equal(rect.right, parentRect.right - 10, 'right ok');
             assert.equal(rect.width, elRect.width, 'no cropping');
+          });
+
+          test('element is kept in viewport', function() {
+            el.horizontalAlign = 'right';
+            // Make it go out of screen.
+            el.horizontalOffset = 1000;
+            el.refit();
+            var rect = el.getBoundingClientRect();
+            assert.equal(rect.left, 0, 'left in viewport');
+            assert.isTrue(rect.width < elRect.width, 'reduced width');
           });
 
           test('element max-width is updated', function() {

--- a/test/iron-fit-behavior.html
+++ b/test/iron-fit-behavior.html
@@ -540,6 +540,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             el.style.minHeight = elRect.height + 'px';
             el.refit();
             var rect = el.getBoundingClientRect();
+            assert.equal(rect.top, 0, 'top ok');
             assert.equal(rect.height, elRect.height, 'min-height ok');
             assert.isTrue(intersects(rect, fitRect), 'partially visible');
           });
@@ -613,6 +614,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             el.style.minHeight = elRect.height + 'px';
             el.refit();
             var rect = el.getBoundingClientRect();
+            assert.equal(rect.top, 0, 'top ok');
             assert.equal(rect.height, elRect.height, 'min-height ok');
             assert.isTrue(intersects(rect, fitRect), 'partially visible');
           });
@@ -748,6 +750,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             el.horizontalAlign = 'left';
             el.refit();
             var rect = el.getBoundingClientRect();
+            assert.equal(rect.left, 0, 'left ok');
             assert.equal(rect.width, elRect.width, 'min-width ok');
             assert.isTrue(intersects(rect, fitRect), 'partially visible');
           });
@@ -825,6 +828,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             el.style.minWidth = elRect.width + 'px';
             el.refit();
             var rect = el.getBoundingClientRect();
+            assert.equal(rect.left, 0, 'left ok');
             assert.equal(rect.width, elRect.width, 'min-width ok');
             assert.isTrue(intersects(rect, fitRect), 'partially visible');
           });

--- a/test/iron-fit-behavior.html
+++ b/test/iron-fit-behavior.html
@@ -425,6 +425,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.closeTo(rect.top - crect.top - (crect.bottom - rect.bottom), 0, 5, 'centered vertically in fitInto');
         });
 
+        test('positioned element fits in another element', function() {
+          var constrain = document.querySelector('.constrain');
+          // element's positionTarget is `body`, and fitInto is `constrain`.
+          var el = fixture('sized-xy');
+          el.verticalAlign = 'top';
+          el.horizontalAlign = 'left';
+          el.fitInto = constrain;
+          el.refit();
+          var rect = el.getBoundingClientRect();
+          var crect = constrain.getBoundingClientRect();
+          assert.equal(rect.top, crect.top, 'top ok');
+          assert.equal(rect.left, crect.left, 'left ok');
+        });
+
       });
 
       suite('horizontal/vertical align', function() {

--- a/test/iron-fit-behavior.html
+++ b/test/iron-fit-behavior.html
@@ -500,6 +500,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.height, elRect.height, 'no cropping');
           });
 
+          test('negative verticalOffset does not crop element', function() {
+            // Push to the bottom of the screen.
+            parent.style.top = (window.innerHeight - 50) +'px';
+            el.verticalAlign = 'top';
+            el.verticalOffset = -10;
+            el.refit();
+            var rect = el.getBoundingClientRect();
+            assert.equal(rect.top, window.innerHeight - 60, 'top ok');
+            assert.equal(rect.bottom, window.innerHeight, 'bottom ok');
+          });
+
           test('max-height is updated', function() {
             parent.style.top = '-10px';
             el.verticalAlign = 'top';
@@ -695,6 +706,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var rect = el.getBoundingClientRect();
             assert.equal(rect.left, parentRect.left + 10, 'left ok');
             assert.equal(rect.width, elRect.width, 'no cropping');
+          });
+
+          test('negative horizontalOffset does not crop element', function() {
+            // Push to the bottom of the screen.
+            parent.style.left = (window.innerWidth - 50) +'px';
+            el.horizontalAlign = 'left';
+            el.horizontalOffset = -10;
+            el.refit();
+            var rect = el.getBoundingClientRect();
+            assert.equal(rect.left, window.innerWidth - 60, 'left ok');
+            assert.equal(rect.right, window.innerWidth, 'right ok');
           });
 
           test('element max-width is updated', function() {


### PR DESCRIPTION
Fixes #54, fixes #55 by associating `verticalOffset` and `horizontalOffset` changes to affect `top, left` rather than `margin-top + margin-bottom` and `margin-left + margin-right`.
