### PR TITLE
Add correct @polymerBehavior annotation

### DIFF
--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -55,7 +55,7 @@ within `fitInto` boundaries, while preserving the element's CSS margin values.
 
 
 @demo demo/index.html
-@polymerBehavior
+@polymerBehavior Polymer.IronFitBehavior
 */
 
   Polymer.IronFitBehavior = {


### PR DESCRIPTION
Hi,

I recently tried to build my Polymer app using polymer-build and this behavior was causing it to fail. It was reporting that it has invalid @polymerBehavior annotation. The fix was simple, just adding the behavior name after the existing annotation and now it builds.