### PR TITLE
Automatic format!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ before_script:
     npm run update-types && git diff --exit-code || (echo -e
     '\n\033[31mERROR:\033[0m Typings are stale. Please run "npm run
     update-types".' && false)
+  - >-
+    npm run format && git diff --exit-code || (echo -e '\n\033[31mERROR:\033[0m
+    Typings are stale. Please run "npm run format".' && false)
 env:
   global:
     - secure: >-

--- a/demo/simple-fit.html
+++ b/demo/simple-fit.html
@@ -23,11 +23,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <slot></slot>
   </template>
   <script>
-    Polymer({
-      is: 'simple-fit',
-      behaviors: [
-        Polymer.IronFitBehavior
-      ]
-    });
+    Polymer({is: 'simple-fit', behaviors: [Polymer.IronFitBehavior]});
   </script>
 </dom-module>

--- a/iron-fit-behavior.d.ts
+++ b/iron-fit-behavior.d.ts
@@ -13,53 +13,59 @@
 declare namespace Polymer {
 
   /**
-   * `Polymer.IronFitBehavior` fits an element in another element using `max-height` and `max-width`, and
-   * optionally centers it in the window or another element.
+   *   `Polymer.IronFitBehavior` fits an element in another element using `max-height`
+   *   and `max-width`, and optionally centers it in the window or another element.
    *
-   * The element will only be sized and/or positioned if it has not already been sized and/or positioned
-   * by CSS.
+   *   The element will only be sized and/or positioned if it has not already been
+   *   sized and/or positioned by CSS.
    *
-   * CSS properties               | Action
-   * -----------------------------|-------------------------------------------
-   * `position` set               | Element is not centered horizontally or vertically
-   * `top` or `bottom` set        | Element is not vertically centered
-   * `left` or `right` set        | Element is not horizontally centered
-   * `max-height` set             | Element respects `max-height`
-   * `max-width` set              | Element respects `max-width`
+   *   CSS properties               | Action
+   *   -----------------------------|-------------------------------------------
+   *   `position` set               | Element is not centered horizontally or
+   *   vertically `top` or `bottom` set        | Element is not vertically centered
+   *   `left` or `right` set        | Element is not horizontally centered
+   *   `max-height` set             | Element respects `max-height`
+   *   `max-width` set              | Element respects `max-width`
    *
-   * `Polymer.IronFitBehavior` can position an element into another element using
-   * `verticalAlign` and `horizontalAlign`. This will override the element's css position.
+   *   `Polymer.IronFitBehavior` can position an element into another element using
+   *   `verticalAlign` and `horizontalAlign`. This will override the element's css
+   *   position.
    *
-   *       <div class="container">
-   *         <iron-fit-impl vertical-align="top" horizontal-align="auto">
-   *           Positioned into the container
-   *         </iron-fit-impl>
-   *       </div>
+   *         <div class="container">
+   *           <iron-fit-impl vertical-align="top" horizontal-align="auto">
+   *             Positioned into the container
+   *           </iron-fit-impl>
+   *         </div>
    *
-   * Use `noOverlap` to position the element around another element without overlapping it.
+   *   Use `noOverlap` to position the element around another element without
+   *   overlapping it.
    *
-   *       <div class="container">
-   *         <iron-fit-impl no-overlap vertical-align="auto" horizontal-align="auto">
-   *           Positioned around the container
-   *         </iron-fit-impl>
-   *       </div>
+   *         <div class="container">
+   *           <iron-fit-impl no-overlap vertical-align="auto" horizontal-align="auto">
+   *             Positioned around the container
+   *           </iron-fit-impl>
+   *         </div>
    *
-   * Use `horizontalOffset, verticalOffset` to offset the element from its `positionTarget`;
-   * `Polymer.IronFitBehavior` will collapse these in order to keep the element
-   * within `fitInto` boundaries, while preserving the element's CSS margin values.
+   *   Use `horizontalOffset, verticalOffset` to offset the element from its
+   *   `positionTarget`; `Polymer.IronFitBehavior` will collapse these in order to keep
+   *   the element within `fitInto` boundaries, while preserving the element's CSS
+   *   margin values.
    *
-   *       <div class="container">
-   *         <iron-fit-impl vertical-align="top" vertical-offset="20">
-   *           With vertical offset
-   *         </iron-fit-impl>
-   *       </div>
+   *         <div class="container">
+   *           <iron-fit-impl vertical-align="top" vertical-offset="20">
+   *             With vertical offset
+   *           </iron-fit-impl>
+   *         </div>
+   *
+   *
+   *   
    */
   interface IronFitBehavior {
 
     /**
-     * The element that will receive a `max-height`/`width`. By default it is the same as `this`,
-     * but it can be set to a child element. This is useful, for example, for implementing a
-     * scrolling region inside the element.
+     * The element that will receive a `max-height`/`width`. By default it is
+     * the same as `this`, but it can be set to a child element. This is useful,
+     * for example, for implementing a scrolling region inside the element.
      */
     sizingTarget: Element;
 
@@ -69,31 +75,35 @@ declare namespace Polymer {
     fitInto: object|null|undefined;
 
     /**
-     * Will position the element around the positionTarget without overlapping it.
+     * Will position the element around the positionTarget without overlapping
+     * it.
      */
     noOverlap: boolean|null|undefined;
 
     /**
-     * The element that should be used to position the element. If not set, it will
-     * default to the parent node.
+     * The element that should be used to position the element. If not set, it
+     * will default to the parent node.
      */
     positionTarget: Element;
 
     /**
      * The orientation against which to align the element horizontally
-     * relative to the `positionTarget`. Possible values are "left", "right", "center", "auto".
+     * relative to the `positionTarget`. Possible values are "left", "right",
+     * "center", "auto".
      */
     horizontalAlign: string|null|undefined;
 
     /**
      * The orientation against which to align the element vertically
-     * relative to the `positionTarget`. Possible values are "top", "bottom", "middle", "auto".
+     * relative to the `positionTarget`. Possible values are "top", "bottom",
+     * "middle", "auto".
      */
     verticalAlign: string|null|undefined;
 
     /**
-     * If true, it will use `horizontalAlign` and `verticalAlign` values as preferred alignment
-     * and if there's not enough space, it will pick the values which minimize the cropping.
+     * If true, it will use `horizontalAlign` and `verticalAlign` values as
+     * preferred alignment and if there's not enough space, it will pick the
+     * values which minimize the cropping.
      */
     dynamicAlign: boolean|null|undefined;
 
@@ -104,8 +114,8 @@ declare namespace Polymer {
      * screen given by `horizontalAlign`.
      *
      * If `horizontalAlign` is "left" or "center", this offset will increase or
-     * decrease the distance to the left side of the screen: a negative offset will
-     * move the dropdown to the left; a positive one, to the right.
+     * decrease the distance to the left side of the screen: a negative offset
+     * will move the dropdown to the left; a positive one, to the right.
      *
      * Conversely if `horizontalAlign` is "right", this offset will increase
      * or decrease the distance to the right side of the screen: a negative
@@ -120,8 +130,8 @@ declare namespace Polymer {
      * screen given by `verticalAlign`.
      *
      * If `verticalAlign` is "top" or "middle", this offset will increase or
-     * decrease the distance to the top side of the screen: a negative offset will
-     * move the dropdown upwards; a positive one, downwards.
+     * decrease the distance to the top side of the screen: a negative offset
+     * will move the dropdown upwards; a positive one, downwards.
      *
      * Conversely if `verticalAlign` is "bottom", this offset will increase
      * or decrease the distance to the bottom side of the screen: a negative
@@ -191,8 +201,8 @@ declare namespace Polymer {
     _sizeDimension(rect: any, positionedBy: any, start: any, end: any, extent: any): void;
 
     /**
-     * Centers horizontally and vertically if not already positioned. This also sets
-     * `position:fixed`.
+     * Centers horizontally and vertically if not already positioned. This also
+     * sets `position:fixed`.
      */
     center(): void;
   }

--- a/iron-fit-behavior.html
+++ b/iron-fit-behavior.html
@@ -11,60 +11,63 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 
 <script>
-/**
-`Polymer.IronFitBehavior` fits an element in another element using `max-height` and `max-width`, and
-optionally centers it in the window or another element.
+  /**
+  `Polymer.IronFitBehavior` fits an element in another element using `max-height`
+  and `max-width`, and optionally centers it in the window or another element.
 
-The element will only be sized and/or positioned if it has not already been sized and/or positioned
-by CSS.
+  The element will only be sized and/or positioned if it has not already been
+  sized and/or positioned by CSS.
 
-CSS properties               | Action
------------------------------|-------------------------------------------
-`position` set               | Element is not centered horizontally or vertically
-`top` or `bottom` set        | Element is not vertically centered
-`left` or `right` set        | Element is not horizontally centered
-`max-height` set             | Element respects `max-height`
-`max-width` set              | Element respects `max-width`
+  CSS properties               | Action
+  -----------------------------|-------------------------------------------
+  `position` set               | Element is not centered horizontally or
+  vertically `top` or `bottom` set        | Element is not vertically centered
+  `left` or `right` set        | Element is not horizontally centered
+  `max-height` set             | Element respects `max-height`
+  `max-width` set              | Element respects `max-width`
 
-`Polymer.IronFitBehavior` can position an element into another element using
-`verticalAlign` and `horizontalAlign`. This will override the element's css position.
+  `Polymer.IronFitBehavior` can position an element into another element using
+  `verticalAlign` and `horizontalAlign`. This will override the element's css
+  position.
 
-      <div class="container">
-        <iron-fit-impl vertical-align="top" horizontal-align="auto">
-          Positioned into the container
-        </iron-fit-impl>
-      </div>
+        <div class="container">
+          <iron-fit-impl vertical-align="top" horizontal-align="auto">
+            Positioned into the container
+          </iron-fit-impl>
+        </div>
 
-Use `noOverlap` to position the element around another element without overlapping it.
+  Use `noOverlap` to position the element around another element without
+  overlapping it.
 
-      <div class="container">
-        <iron-fit-impl no-overlap vertical-align="auto" horizontal-align="auto">
-          Positioned around the container
-        </iron-fit-impl>
-      </div>
+        <div class="container">
+          <iron-fit-impl no-overlap vertical-align="auto" horizontal-align="auto">
+            Positioned around the container
+          </iron-fit-impl>
+        </div>
 
-Use `horizontalOffset, verticalOffset` to offset the element from its `positionTarget`;
-`Polymer.IronFitBehavior` will collapse these in order to keep the element
-within `fitInto` boundaries, while preserving the element's CSS margin values.
+  Use `horizontalOffset, verticalOffset` to offset the element from its
+  `positionTarget`; `Polymer.IronFitBehavior` will collapse these in order to keep
+  the element within `fitInto` boundaries, while preserving the element's CSS
+  margin values.
 
-      <div class="container">
-        <iron-fit-impl vertical-align="top" vertical-offset="20">
-          With vertical offset
-        </iron-fit-impl>
-      </div>
+        <div class="container">
+          <iron-fit-impl vertical-align="top" vertical-offset="20">
+            With vertical offset
+          </iron-fit-impl>
+        </div>
 
 
-@demo demo/index.html
-@polymerBehavior
-*/
+  @demo demo/index.html
+  @polymerBehavior
+  */
   Polymer.IronFitBehavior = {
 
     properties: {
 
       /**
-       * The element that will receive a `max-height`/`width`. By default it is the same as `this`,
-       * but it can be set to a child element. This is useful, for example, for implementing a
-       * scrolling region inside the element.
+       * The element that will receive a `max-height`/`width`. By default it is
+       * the same as `this`, but it can be set to a child element. This is useful,
+       * for example, for implementing a scrolling region inside the element.
        * @type {!Element}
        */
       sizingTarget: {
@@ -77,50 +80,41 @@ within `fitInto` boundaries, while preserving the element's CSS margin values.
       /**
        * The element to fit `this` into.
        */
-      fitInto: {
-        type: Object,
-        value: window
-      },
+      fitInto: {type: Object, value: window},
 
       /**
-       * Will position the element around the positionTarget without overlapping it.
+       * Will position the element around the positionTarget without overlapping
+       * it.
        */
-      noOverlap: {
-        type: Boolean
-      },
+      noOverlap: {type: Boolean},
 
       /**
-       * The element that should be used to position the element. If not set, it will
-       * default to the parent node.
+       * The element that should be used to position the element. If not set, it
+       * will default to the parent node.
        * @type {!Element}
        */
-      positionTarget: {
-        type: Element
-      },
+      positionTarget: {type: Element},
 
       /**
        * The orientation against which to align the element horizontally
-       * relative to the `positionTarget`. Possible values are "left", "right", "center", "auto".
+       * relative to the `positionTarget`. Possible values are "left", "right",
+       * "center", "auto".
        */
-      horizontalAlign: {
-        type: String
-      },
+      horizontalAlign: {type: String},
 
       /**
        * The orientation against which to align the element vertically
-       * relative to the `positionTarget`. Possible values are "top", "bottom", "middle", "auto".
+       * relative to the `positionTarget`. Possible values are "top", "bottom",
+       * "middle", "auto".
        */
-      verticalAlign: {
-        type: String
-      },
+      verticalAlign: {type: String},
 
       /**
-       * If true, it will use `horizontalAlign` and `verticalAlign` values as preferred alignment
-       * and if there's not enough space, it will pick the values which minimize the cropping.
+       * If true, it will use `horizontalAlign` and `verticalAlign` values as
+       * preferred alignment and if there's not enough space, it will pick the
+       * values which minimize the cropping.
        */
-      dynamicAlign: {
-        type: Boolean
-      },
+      dynamicAlign: {type: Boolean},
 
       /**
        * A pixel value that will be added to the position calculated for the
@@ -129,18 +123,14 @@ within `fitInto` boundaries, while preserving the element's CSS margin values.
        * screen given by `horizontalAlign`.
        *
        * If `horizontalAlign` is "left" or "center", this offset will increase or
-       * decrease the distance to the left side of the screen: a negative offset will
-       * move the dropdown to the left; a positive one, to the right.
+       * decrease the distance to the left side of the screen: a negative offset
+       * will move the dropdown to the left; a positive one, to the right.
        *
        * Conversely if `horizontalAlign` is "right", this offset will increase
        * or decrease the distance to the right side of the screen: a negative
        * offset will move the dropdown to the right; a positive one, to the left.
        */
-      horizontalOffset: {
-        type: Number,
-        value: 0,
-        notify: true
-      },
+      horizontalOffset: {type: Number, value: 0, notify: true},
 
       /**
        * A pixel value that will be added to the position calculated for the
@@ -149,31 +139,22 @@ within `fitInto` boundaries, while preserving the element's CSS margin values.
        * screen given by `verticalAlign`.
        *
        * If `verticalAlign` is "top" or "middle", this offset will increase or
-       * decrease the distance to the top side of the screen: a negative offset will
-       * move the dropdown upwards; a positive one, downwards.
+       * decrease the distance to the top side of the screen: a negative offset
+       * will move the dropdown upwards; a positive one, downwards.
        *
        * Conversely if `verticalAlign` is "bottom", this offset will increase
        * or decrease the distance to the bottom side of the screen: a negative
        * offset will move the dropdown downwards; a positive one, upwards.
        */
-      verticalOffset: {
-        type: Number,
-        value: 0,
-        notify: true
-      },
+      verticalOffset: {type: Number, value: 0, notify: true},
 
       /**
        * Set to true to auto-fit on attach.
        */
-      autoFitOnAttach: {
-        type: Boolean,
-        value: false
-      },
+      autoFitOnAttach: {type: Boolean, value: false},
 
       /** @type {?Object} */
-      _fitInfo: {
-        type: Object
-      }
+      _fitInfo: {type: Object}
     },
 
     get _fitWidth() {
@@ -252,7 +233,7 @@ within `fitInto` boundaries, while preserving the element's CSS margin values.
      */
     get __shouldPosition() {
       return (this.horizontalAlign || this.verticalAlign) &&
-        (this.horizontalAlign !== 'center' || this.verticalAlign !== 'middle');
+          (this.horizontalAlign !== 'center' || this.verticalAlign !== 'middle');
     },
 
     attached: function() {
@@ -316,10 +297,12 @@ within `fitInto` boundaries, while preserving the element's CSS margin values.
           boxSizing: this.sizingTarget.style.boxSizing || ''
         },
         positionedBy: {
-          vertically: target.top !== 'auto' ? 'top' : (target.bottom !== 'auto' ?
-            'bottom' : null),
-          horizontally: target.left !== 'auto' ? 'left' : (target.right !== 'auto' ?
-            'right' : null)
+          vertically: target.top !== 'auto' ?
+              'top' :
+              (target.bottom !== 'auto' ? 'bottom' : null),
+          horizontally: target.left !== 'auto' ?
+              'left' :
+              (target.right !== 'auto' ? 'right' : null)
         },
         sizedBy: {
           height: sizer.maxHeight !== 'none',
@@ -380,7 +363,8 @@ within `fitInto` boundaries, while preserving the element's CSS margin values.
       this.style.position = 'fixed';
       // Need border-box for margin/padding.
       this.sizingTarget.style.boxSizing = 'border-box';
-      // Set to 0, 0 in order to discover any offset caused by parent stacking contexts.
+      // Set to 0, 0 in order to discover any offset caused by parent stacking
+      // contexts.
       this.style.left = '0px';
       this.style.top = '0px';
 
@@ -396,8 +380,13 @@ within `fitInto` boundaries, while preserving the element's CSS margin values.
         height: rect.height + margin.top + margin.bottom
       };
 
-      var position = this.__getPosition(this._localeHorizontalAlign, this.verticalAlign, size, rect, positionRect,
-        fitRect);
+      var position = this.__getPosition(
+          this._localeHorizontalAlign,
+          this.verticalAlign,
+          size,
+          rect,
+          positionRect,
+          fitRect);
 
       var left = position.left + margin.left;
       var top = position.top + margin.top;
@@ -408,14 +397,19 @@ within `fitInto` boundaries, while preserving the element's CSS margin values.
       var bottom = Math.min(fitRect.bottom - margin.bottom, top + rect.height);
 
       // Keep left/top within fitInto respecting the margin.
-      left = Math.max(fitRect.left + margin.left,
-        Math.min(left, right - this._fitInfo.sizedBy.minWidth));
-      top = Math.max(fitRect.top + margin.top,
-        Math.min(top, bottom - this._fitInfo.sizedBy.minHeight));
+      left = Math.max(
+          fitRect.left + margin.left,
+          Math.min(left, right - this._fitInfo.sizedBy.minWidth));
+      top = Math.max(
+          fitRect.top + margin.top,
+          Math.min(top, bottom - this._fitInfo.sizedBy.minHeight));
 
-      // Use right/bottom to set maxWidth/maxHeight, and respect minWidth/minHeight.
-      this.sizingTarget.style.maxWidth = Math.max(right - left, this._fitInfo.sizedBy.minWidth) + 'px';
-      this.sizingTarget.style.maxHeight = Math.max(bottom - top, this._fitInfo.sizedBy.minHeight) + 'px';
+      // Use right/bottom to set maxWidth/maxHeight, and respect
+      // minWidth/minHeight.
+      this.sizingTarget.style.maxWidth =
+          Math.max(right - left, this._fitInfo.sizedBy.minWidth) + 'px';
+      this.sizingTarget.style.maxHeight =
+          Math.max(bottom - top, this._fitInfo.sizedBy.minHeight) + 'px';
 
       // Remove the offset caused by any stacking context.
       this.style.left = (left - rect.left) + 'px';
@@ -433,7 +427,8 @@ within `fitInto` boundaries, while preserving the element's CSS margin values.
       this._discoverInfo();
 
       var info = this._fitInfo;
-      // position at (0px, 0px) if not already positioned, so we can measure the natural size.
+      // position at (0px, 0px) if not already positioned, so we can measure the
+      // natural size.
       if (!info.positionedBy.vertically) {
         this.style.position = 'fixed';
         this.style.top = '0px';
@@ -448,10 +443,12 @@ within `fitInto` boundaries, while preserving the element's CSS margin values.
       // constrain the width and height if not already set
       var rect = this.getBoundingClientRect();
       if (!info.sizedBy.height) {
-        this.__sizeDimension(rect, info.positionedBy.vertically, 'top', 'bottom', 'Height');
+        this.__sizeDimension(
+            rect, info.positionedBy.vertically, 'top', 'bottom', 'Height');
       }
       if (!info.sizedBy.width) {
-        this.__sizeDimension(rect, info.positionedBy.horizontally, 'left', 'right', 'Width');
+        this.__sizeDimension(
+            rect, info.positionedBy.horizontally, 'left', 'right', 'Width');
       }
     },
 
@@ -475,12 +472,13 @@ within `fitInto` boundaries, while preserving the element's CSS margin values.
       var margin = info.margin[flip ? start : end];
       var offsetExtent = 'offset' + extent;
       var sizingOffset = this[offsetExtent] - this.sizingTarget[offsetExtent];
-      this.sizingTarget.style['max' + extent] = (max - margin - offset - sizingOffset) + 'px';
+      this.sizingTarget.style['max' + extent] =
+          (max - margin - offset - sizingOffset) + 'px';
     },
 
     /**
-     * Centers horizontally and vertically if not already positioned. This also sets
-     * `position:fixed`.
+     * Centers horizontally and vertically if not already positioned. This also
+     * sets `position:fixed`.
      */
     center: function() {
       if (this.__shouldPosition) {
@@ -532,36 +530,45 @@ within `fitInto` boundaries, while preserving the element's CSS margin values.
     },
 
     __getOffscreenArea: function(position, size, fitRect) {
-      var verticalCrop = Math.min(0, position.top) + Math.min(0, fitRect.bottom - (position.top + size.height));
-      var horizontalCrop = Math.min(0, position.left) + Math.min(0, fitRect.right - (position.left + size.width));
-      return Math.abs(verticalCrop) * size.width + Math.abs(horizontalCrop) * size.height;
+      var verticalCrop = Math.min(0, position.top) +
+          Math.min(0, fitRect.bottom - (position.top + size.height));
+      var horizontalCrop = Math.min(0, position.left) +
+          Math.min(0, fitRect.right - (position.left + size.width));
+      return Math.abs(verticalCrop) * size.width +
+          Math.abs(horizontalCrop) * size.height;
     },
 
 
-    __getPosition: function(hAlign, vAlign, size, sizeNoMargins, positionRect, fitRect) {
+    __getPosition: function(
+        hAlign, vAlign, size, sizeNoMargins, positionRect, fitRect) {
       // All the possible configurations.
       // Ordered as top-left, top-right, bottom-left, bottom-right.
-      var positions = [{
-        verticalAlign: 'top',
-        horizontalAlign: 'left',
-        top: positionRect.top + this.verticalOffset,
-        left: positionRect.left + this.horizontalOffset
-      }, {
-        verticalAlign: 'top',
-        horizontalAlign: 'right',
-        top: positionRect.top + this.verticalOffset,
-        left: positionRect.right - size.width - this.horizontalOffset
-      }, {
-        verticalAlign: 'bottom',
-        horizontalAlign: 'left',
-        top: positionRect.bottom - size.height - this.verticalOffset,
-        left: positionRect.left + this.horizontalOffset
-      }, {
-        verticalAlign: 'bottom',
-        horizontalAlign: 'right',
-        top: positionRect.bottom - size.height - this.verticalOffset,
-        left: positionRect.right - size.width - this.horizontalOffset
-      }];
+      var positions = [
+        {
+          verticalAlign: 'top',
+          horizontalAlign: 'left',
+          top: positionRect.top + this.verticalOffset,
+          left: positionRect.left + this.horizontalOffset
+        },
+        {
+          verticalAlign: 'top',
+          horizontalAlign: 'right',
+          top: positionRect.top + this.verticalOffset,
+          left: positionRect.right - size.width - this.horizontalOffset
+        },
+        {
+          verticalAlign: 'bottom',
+          horizontalAlign: 'left',
+          top: positionRect.bottom - size.height - this.verticalOffset,
+          left: positionRect.left + this.horizontalOffset
+        },
+        {
+          verticalAlign: 'bottom',
+          horizontalAlign: 'right',
+          top: positionRect.bottom - size.height - this.verticalOffset,
+          left: positionRect.right - size.width - this.horizontalOffset
+        }
+      ];
 
       if (this.noOverlap) {
         // Duplicate.
@@ -588,14 +595,18 @@ within `fitInto` boundaries, while preserving the element's CSS margin values.
         positions.push({
           verticalAlign: 'top',
           horizontalAlign: 'center',
-          top: positionRect.top + this.verticalOffset + (this.noOverlap ? positionRect.height : 0),
-          left: positionRect.left - sizeNoMargins.width / 2 + positionRect.width / 2 + this.horizontalOffset
+          top: positionRect.top + this.verticalOffset +
+              (this.noOverlap ? positionRect.height : 0),
+          left: positionRect.left - sizeNoMargins.width / 2 +
+              positionRect.width / 2 + this.horizontalOffset
         });
         positions.push({
           verticalAlign: 'bottom',
           horizontalAlign: 'center',
-          top: positionRect.bottom - size.height - this.verticalOffset - (this.noOverlap ? positionRect.height : 0),
-          left: positionRect.left - sizeNoMargins.width / 2 + positionRect.width / 2 + this.horizontalOffset
+          top: positionRect.bottom - size.height - this.verticalOffset -
+              (this.noOverlap ? positionRect.height : 0),
+          left: positionRect.left - sizeNoMargins.width / 2 +
+              positionRect.width / 2 + this.horizontalOffset
         });
       }
 
@@ -603,14 +614,18 @@ within `fitInto` boundaries, while preserving the element's CSS margin values.
         positions.push({
           verticalAlign: 'middle',
           horizontalAlign: 'left',
-          top: positionRect.top - sizeNoMargins.height / 2 + positionRect.height / 2 + this.verticalOffset,
-          left: positionRect.left + this.horizontalOffset + (this.noOverlap ? positionRect.width : 0)
+          top: positionRect.top - sizeNoMargins.height / 2 +
+              positionRect.height / 2 + this.verticalOffset,
+          left: positionRect.left + this.horizontalOffset +
+              (this.noOverlap ? positionRect.width : 0)
         });
         positions.push({
           verticalAlign: 'middle',
           horizontalAlign: 'right',
-          top: positionRect.top - sizeNoMargins.height / 2 + positionRect.height / 2 + this.verticalOffset,
-          left: positionRect.right - size.width - this.horizontalOffset - (this.noOverlap ? positionRect.width : 0)
+          top: positionRect.top - sizeNoMargins.height / 2 +
+              positionRect.height / 2 + this.verticalOffset,
+          left: positionRect.right - size.width - this.horizontalOffset -
+              (this.noOverlap ? positionRect.width : 0)
         });
       }
 
@@ -639,7 +654,8 @@ within `fitInto` boundaries, while preserving the element's CSS margin values.
           continue;
         }
 
-        candidate.offscreenArea = this.__getOffscreenArea(candidate, size, fitRect);
+        candidate.offscreenArea =
+            this.__getOffscreenArea(candidate, size, fitRect);
         // If not cropped and respects the align requirements, keep it.
         // This allows to prefer positions overlapping horizontally over the
         // ones overlapping vertically.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,23 +3,34 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
+      }
+    },
     "@polymer/gen-typescript-declarations": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-1.2.0.tgz",
-      "integrity": "sha512-a5DFXI3TdZSVOMH4608LVaBLmcr+mwM2+B8OSBiB9WFNCtdqzUXwtB5We6vBzrThXlO4uRo7d2pEqjNXMAlEkA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-1.2.2.tgz",
+      "integrity": "sha512-9P946+nIkSm+761v3oxH/QVgJozhsInldKY3h8AVstdXkA8W0Fij84pqsFv1nrRuPGj4Pv71crzoZpFnLkNmKQ==",
       "dev": true,
       "requires": {
         "@types/doctrine": "0.0.3",
-        "@types/fs-extra": "5.0.0",
+        "@types/fs-extra": "5.0.1",
         "@types/glob": "5.0.35",
         "command-line-args": "5.0.2",
-        "command-line-usage": "4.1.0",
+        "command-line-usage": "5.0.4",
         "doctrine": "2.1.0",
-        "escodegen": "1.9.0",
+        "escodegen": "1.9.1",
         "fs-extra": "5.0.0",
         "glob": "7.1.2",
         "minimatch": "3.0.4",
-        "polymer-analyzer": "3.0.0-pre.12"
+        "polymer-analyzer": "3.0.0-pre.14",
+        "vscode-uri": "1.0.3"
       }
     },
     "@types/babel-generator": {
@@ -95,18 +106,18 @@
       "dev": true
     },
     "@types/events": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
-      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-qtxDULQKUenuaDLW003CgC+0T0eiAfH3BrH+vSt87GLzbz5EZ6Ox6mv9rMttvhDOatbb9nYh0E1m7ydoYwUrAg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.1.tgz",
+      "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.3"
       }
     },
     "@types/glob": {
@@ -115,10 +126,16 @@
       "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "dev": true,
       "requires": {
-        "@types/events": "1.1.0",
+        "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.3"
       }
+    },
+    "@types/is-windows": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
+      "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8=",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -127,9 +144,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.4.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
-      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.3.tgz",
+      "integrity": "sha512-igaEysRgtg5tYJVIdQ1T2lJ3G6OmoY7g0YVWKHLFiVs4YUChd9IRSiLoHSLffwut+CpsHHBDj4vRxxNEMstctw==",
       "dev": true
     },
     "@types/parse5": {
@@ -138,25 +155,25 @@
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.3"
+      }
+    },
+    "@types/resolve": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
+      "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.6.3"
       }
     },
     "@types/winston": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.8.tgz",
-      "integrity": "sha512-QqR0j08RCS1AQYPMRPHikEpcmK+2aEEbcSzWLwOqyJ4FhLmHUx/WjRrnn7tTQg/y4IKnMhzskh/o7qvGIZZ7iA==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.9.tgz",
+      "integrity": "sha512-zzruYOEtNgfS3SBjcij1F6HlH6My5n8WrBNhP3fzaRM22ba70QBC2ATs18jGr88Fy43c0z8vFJv5wJankfxv2A==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
-      }
-    },
-    "ansi-escape-sequences": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
-      "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0"
+        "@types/node": "9.6.3"
       }
     },
     "ansi-regex": {
@@ -166,10 +183,13 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "1.9.1"
+      }
     },
     "argv-tools": {
       "version": "0.1.1",
@@ -181,6 +201,24 @@
         "find-replace": "2.0.1"
       }
     },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
     "array-back": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
@@ -190,19 +228,37 @@
         "typical": "2.6.1"
       }
     },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
     "async": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
       "dev": true
     },
+    "atob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
+      "dev": true
+    },
     "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz",
+      "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "chalk": "2.3.2",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
       }
@@ -221,6 +277,47 @@
         "lodash": "4.17.5",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.5",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.3.tgz",
+      "integrity": "sha512-iMWYqwDarQOVlEGcK1MfbtK9vrFGs5Z4UQsdASJUHdhBp918EM5kndwriiIbhUX8gr2B/CEV/udJkFTrHsjdMQ==",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "7.0.0-beta.3",
+        "babel-template": "7.0.0-beta.3",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.3.tgz",
+      "integrity": "sha512-ZkYFRMWKx1c9fUW72YNM3eieBG701CMbLjmLLWmJTTPc0F0kddS9Fwok26EAmndUAgD6kFdh7ms3PH94MdGuGQ==",
+      "dev": true,
+      "requires": {
+        "babel-types": "7.0.0-beta.3"
       }
     },
     "babel-messages": {
@@ -238,43 +335,78 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.5",
         "regenerator-runtime": "0.11.1"
       }
     },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+    "babel-template": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.3.tgz",
+      "integrity": "sha512-urJduLja89kSDGqY8ryw8iIwQnMl30IvhMtMNmDD7vBX0l0oylaLgK+7df/9ODX9vR/PhXuif6HYl5HlzAKXMg==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
+        "babel-code-frame": "7.0.0-beta.3",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.27",
         "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.27",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
+          "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-traverse": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.3.tgz",
+      "integrity": "sha512-xyh/aPYuedMAfQlSj2kjHjsEmY5/Dpxs576L05DySAVMrV+ADX6l4mTOLysAEGwJfkePJlDLhFuS6SKaxv1V7w==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "7.0.0-beta.3",
+        "babel-helper-function-name": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.27",
+        "debug": "3.1.0",
+        "globals": "10.4.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.27",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
+          "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
+          "dev": true
+        }
       }
     },
     "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
+      "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
         "lodash": "4.17.5",
-        "to-fast-properties": "1.0.3"
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
       }
     },
     "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
       "dev": true
     },
     "balanced-match": {
@@ -283,10 +415,65 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
     "bower": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
-      "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc=",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.4.tgz",
+      "integrity": "sha1-54dqB23rgTf30GUl3F6MZtuC8oo=",
       "dev": true
     },
     "brace-expansion": {
@@ -299,23 +486,157 @@
         "concat-map": "0.0.1"
       }
     },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.2",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
+      }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
+    "cancel-token": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
+      "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
+      "dev": true,
+      "requires": {
+        "@types/node": "4.2.23"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "4.2.23",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.23.tgz",
+          "integrity": "sha512-U6IchCNLRyswc9p6G6lxWlbE+KwAhZp6mGo6MD2yWpmFomhYmetK+c98OpKyvphNn04CU3aXeJrXdOqbXVTS/w==",
+          "dev": true
+        }
+      }
+    },
+    "chalk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "supports-color": "5.3.0"
+      }
+    },
+    "clang-format": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.2.3.tgz",
+      "integrity": "sha512-x90Hac4ERacGDcZSvHKK58Ga0STuMD+Doi5g0iG2zf7wlJef5Huvhs/3BvMRFxwRYyYSdl6mpQNrtfMxE8MQzw==",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "glob": "7.1.2",
+        "resolve": "1.7.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
       }
     },
     "clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
@@ -338,16 +659,22 @@
       }
     },
     "command-line-usage": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-      "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-h17lBwC5bl5RdukPbXji75+cg2/Qbny6kGsmLoy34s9DNH90RwRvJKb+VU5j4YY9HzYl7twLaOWDJQ4b9U+p/Q==",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "4.0.0",
         "array-back": "2.0.0",
-        "table-layout": "0.4.2",
+        "chalk": "2.3.2",
+        "table-layout": "0.4.3",
         "typical": "2.6.1"
       }
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -355,10 +682,16 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
     "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
       "dev": true
     },
     "cssbeautify": {
@@ -374,13 +707,19 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "deep-extend": {
       "version": "0.5.0",
@@ -393,6 +732,47 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -419,7 +799,7 @@
       "dev": true,
       "requires": {
         "@types/parse5": "2.2.34",
-        "clone": "2.1.1",
+        "clone": "2.1.2",
         "parse5": "4.0.0"
       }
     },
@@ -430,16 +810,16 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "dev": true,
       "requires": {
         "esprima": "3.1.3",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "optionator": "0.8.2",
-        "source-map": "0.5.7"
+        "source-map": "0.6.1"
       }
     },
     "esprima": {
@@ -460,17 +840,183 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
     "eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "dev": true
     },
+    "fast-glob": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.0.tgz",
+      "integrity": "sha512-4F75PTznkNtSKs2pbhtBwRkw8sRwa7LfXx5XaQJOe4IQ6yTjceLDTwM5gj1s80R2t/5WeDC1gVfm3jLE+l39Tw==",
+      "dev": true,
+      "requires": {
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.1",
+        "micromatch": "3.1.10"
+      }
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
     },
     "find-replace": {
       "version": "2.0.1",
@@ -480,6 +1026,21 @@
       "requires": {
         "array-back": "2.0.0",
         "test-value": "3.0.0"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "0.2.2"
       }
     },
     "fs-extra": {
@@ -499,6 +1060,12 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -513,10 +1080,37 @@
         "path-is-absolute": "1.0.1"
       }
     },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        }
+      }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
+    },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+      "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
       "dev": true
     },
     "graceful-fs": {
@@ -532,6 +1126,44 @@
       "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
     },
     "indent": {
@@ -557,13 +1189,90 @@
       "dev": true
     },
     "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -573,6 +1282,79 @@
       "requires": {
         "number-is-nan": "1.0.1"
       }
+    },
+    "is-glob": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-odd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -602,9 +1384,15 @@
       }
     },
     "jsonschema": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
-      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
     },
     "levn": {
@@ -635,6 +1423,12 @@
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
       "dev": true
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
@@ -642,6 +1436,48 @@
       "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "1.0.1"
+      }
+    },
+    "merge2": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.1.tgz",
+      "integrity": "sha512-wUqcG5pxrAcaFI1lkqkMnk3Q7nUxV/NWfpAFSeWUwG9TRODnBDCUHa75mi3o3vLWQ5N4CQERWCauSlP0I3ZqUg==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.9",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "minimatch": {
@@ -662,17 +1498,107 @@
         "minimatch": "3.0.4"
       }
     },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "nanomatch": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -703,10 +1629,34 @@
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
     },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "plylog": {
@@ -716,8 +1666,8 @@
       "dev": true,
       "requires": {
         "@types/node": "4.2.23",
-        "@types/winston": "2.3.8",
-        "winston": "2.4.0"
+        "@types/winston": "2.3.9",
+        "winston": "2.4.1"
       },
       "dependencies": {
         "@types/node": {
@@ -729,9 +1679,9 @@
       }
     },
     "polymer-analyzer": {
-      "version": "3.0.0-pre.12",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.12.tgz",
-      "integrity": "sha512-QQL70IC85hI6q9uQeresEMcT1Qf8YR/zDe1qG8WWeeFAZk8z0lmzUpsfcAWz+bM4wpDdXrtd4HitIs4p0CHl/w==",
+      "version": "3.0.0-pre.14",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.14.tgz",
+      "integrity": "sha512-1Zh/smUWMrjBB7NFUk8i7EAnjO81PqhI0/RzMMy9VgAbPQ6jOROwFX71T02CgpkZYa0O66Ybl7G3+4+0S1aF1Q==",
       "dev": true,
       "requires": {
         "@types/babel-generator": "6.25.1",
@@ -743,27 +1693,34 @@
         "@types/clone": "0.1.30",
         "@types/cssbeautify": "0.3.1",
         "@types/doctrine": "0.0.1",
+        "@types/is-windows": "0.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "6.0.101",
+        "@types/node": "6.0.105",
         "@types/parse5": "2.2.34",
+        "@types/resolve": "0.0.6",
         "babel-generator": "6.26.1",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.44",
+        "cancel-token": "0.1.1",
         "chalk": "1.1.3",
-        "clone": "2.1.1",
+        "clone": "2.1.2",
         "cssbeautify": "0.3.1",
         "doctrine": "2.1.0",
         "dom5": "3.0.0",
         "indent": "0.0.2",
-        "jsonschema": "1.2.2",
+        "is-windows": "1.0.2",
+        "jsonschema": "1.2.4",
         "minimatch": "3.0.4",
         "parse5": "4.0.0",
-        "polymer-project-config": "3.8.1",
+        "path-is-inside": "1.0.2",
+        "polymer-project-config": "3.13.0",
+        "resolve": "1.7.0",
         "shady-css-parser": "0.1.0",
         "stable": "0.1.6",
         "strip-indent": "2.0.0",
-        "vscode-uri": "1.0.1"
+        "vscode-uri": "1.0.3",
+        "whatwg-url": "6.4.0"
       },
       "dependencies": {
         "@types/doctrine": {
@@ -773,37 +1730,74 @@
           "dev": true
         },
         "@types/node": {
-          "version": "6.0.101",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
-          "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw==",
+          "version": "6.0.105",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.105.tgz",
+          "integrity": "sha512-fMIbw7iw91TSInS3b2DtDse5VaQEZqs0oTjvRNIFHnoHbnji+dLwpzL1L6dYGL39RzDNPHM/Off+VNcMk4ahwQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "polymer-project-config": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.8.1.tgz",
-      "integrity": "sha512-MLvnM9gexFWg7nynY24eHZG6NLXocmk718sVds/sx2CAJ6iihhC0JMhhOIa6jnad9KQrHyGl/cs3mMRaaub5Fg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.13.0.tgz",
+      "integrity": "sha512-0E1iSOpo2xFMvMomSDFl48J8IOUWmM+sfHGJSQSVfIu8GXDgz2TVraad+rEMZDbj8uxiRFvQZyouHhikxhVFpQ==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.101",
-        "jsonschema": "1.2.2",
+        "@types/node": "6.0.105",
+        "jsonschema": "1.2.4",
         "minimatch-all": "1.1.0",
         "plylog": "0.5.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.101",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
-          "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw==",
+          "version": "6.0.105",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.105.tgz",
+          "integrity": "sha512-fMIbw7iw91TSInS3b2DtDse5VaQEZqs0oTjvRNIFHnoHbnji+dLwpzL1L6dYGL39RzDNPHM/Off+VNcMk4ahwQ==",
           "dev": true
         }
       }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
       "dev": true
     },
     "reduce-flatten": {
@@ -818,6 +1812,28 @@
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
@@ -827,17 +1843,221 @@
         "is-finite": "1.0.2"
       }
     },
+    "resolve": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
+      "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "0.1.15"
+      }
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
     "shady-css-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
       "integrity": "sha512-irfJUUkEuDlNHKZNAp2r7zOyMlmbfVJ+kWSfjlCYYUx/7dJnANLCyTzQZsuxy5NJkvtNwSxY5Gj8MOlqXUQPyA==",
       "dev": true
     },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "optional": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+      "dev": true,
+      "requires": {
+        "atob": "2.1.0",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2"
+      }
     },
     "stable": {
       "version": "0.1.6",
@@ -850,6 +2070,27 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -867,15 +2108,18 @@
       "dev": true
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+      "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+      "dev": true,
+      "requires": {
+        "has-flag": "3.0.0"
+      }
     },
     "table-layout": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
-      "integrity": "sha512-tygyl5+eSHj4chpq5Zfy6cpc7MOUBClAW9ozghFH7hg9bAUzShOYn+/vUzTRkKOSLJWKfgYtP2tAU2c0oAD8eg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.3.tgz",
+      "integrity": "sha512-MIhflPM38ejKrFwWwC3P9x3eHvMo5G5AmNo29Qtz2HpBl5KD2GCcmOErjgNtUQLv/qaqVDagfJY3rJLPDvEgLg==",
       "dev": true,
       "requires": {
         "array-back": "2.0.0",
@@ -901,6 +2145,57 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.0"
+      }
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -922,22 +2217,141 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
       "dev": true
     },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
+      }
+    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
       "dev": true
     },
-    "vscode-uri": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
-      "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g=",
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "use": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+      "dev": true,
+      "requires": {
+        "kind-of": "6.0.2"
+      }
+    },
+    "vscode-uri": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
+      "integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI=",
+      "dev": true
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "webmat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/webmat/-/webmat-0.2.0.tgz",
+      "integrity": "sha512-xf2iHrssbbTofFwxvrdtgSxILQ8ledlpeDc76fNkTEL76gGnxCB/YA69UF498+UPfYIDvVnk9Qt2E7MJOApacA==",
+      "dev": true,
+      "requires": {
+        "clang-format": "1.2.3",
+        "dom5": "3.0.0",
+        "fast-glob": "2.2.0",
+        "parse5": "4.0.0"
+      }
+    },
+    "whatwg-url": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
+      }
+    },
     "winston": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
-      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
+      "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
       "dev": true,
       "requires": {
         "async": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
   "license": "BSD-3-Clause",
   "devDependencies": {
     "@polymer/gen-typescript-declarations": "^1.2.0",
-    "bower": "^1.8.0"
+    "bower": "^1.8.0",
+    "webmat": "^0.2.0"
   },
   "scripts": {
-    "update-types": "bower install && gen-typescript-declarations --deleteExisting --outDir ."
+    "update-types": "bower install && gen-typescript-declarations --deleteExisting --outDir .",
+    "format": "webmat && npm run update-types"
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -21,8 +21,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script>
       WCT.loadSuites([
-        'iron-fit-behavior.html?wc-shadydom=true&wc-ce=true', //shady
-        'iron-fit-behavior.html?dom=shadow' //shadow
+        'iron-fit-behavior.html?wc-shadydom=true&wc-ce=true',  // shady
+        'iron-fit-behavior.html?dom=shadow'                    // shadow
       ]);
     </script>
 

--- a/test/iron-fit-behavior.html
+++ b/test/iron-fit-behavior.html
@@ -197,7 +197,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
 
     <script>
-
       function makeScrolling(el) {
         el.classList.add('scrolling');
         var template = document.getElementById('ipsum');
@@ -207,11 +206,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       function intersects(r1, r2) {
-        return !(r2.left >= r1.right || r2.right <= r1.left || r2.top >= r1.bottom || r2.bottom <= r1.top);
+        return !(
+            r2.left >= r1.right || r2.right <= r1.left || r2.top >= r1.bottom ||
+            r2.bottom <= r1.top);
       }
 
       suite('basic', function() {
-
         var el;
         setup(function() {
           el = fixture('basic');
@@ -236,27 +236,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('center() works without autoFitOnAttach', function() {
           el.center();
           var rect = el.getBoundingClientRect();
-          assert.closeTo(rect.left - (window.innerWidth - rect.right), 0, 5, 'centered horizontally');
-          assert.closeTo(rect.top - (window.innerHeight - rect.bottom), 0, 5, 'centered vertically');
+          assert.closeTo(
+              rect.left - (window.innerWidth - rect.right),
+              0,
+              5,
+              'centered horizontally');
+          assert.closeTo(
+              rect.top - (window.innerHeight - rect.bottom),
+              0,
+              5,
+              'centered vertically');
         });
-
       });
 
       suite('manual positioning', function() {
-
         test('css positioned element is not re-positioned', function() {
           var el = fixture('positioned-xy');
           var rect = el.getBoundingClientRect();
           assert.equal(rect.top, 100, 'top is unset');
           assert.equal(rect.left, 100, 'left is unset');
-
         });
 
         test('inline positioned element is not re-positioned', function() {
           var el = fixture('inline-positioned-xy');
           var rect = el.getBoundingClientRect();
-          // need to measure document.body here because mocha sets a min-width on html,body, and
-          // the element is positioned wrt to that by css
+          // need to measure document.body here because mocha sets a min-width on
+          // html,body, and the element is positioned wrt to that by css
           var bodyRect = document.body.getBoundingClientRect();
           assert.equal(rect.top, 100, 'top is unset');
           assert.equal(rect.left, 100, 'left is unset');
@@ -266,22 +271,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           rect = el.getBoundingClientRect();
           assert.equal(rect.top, 100, 'top is unset after refit');
           assert.equal(rect.left, 100, 'left is unset after refit');
-
         });
 
         test('position property is preserved after', function() {
           var el = fixture('absolute');
-          assert.equal(getComputedStyle(el).position, 'absolute', 'position:absolute is preserved');
+          assert.equal(
+              getComputedStyle(el).position,
+              'absolute',
+              'position:absolute is preserved');
         });
       });
 
       suite('fit to window', function() {
-
         test('sized element is centered in viewport', function() {
           var el = fixture('sized-xy');
           var rect = el.getBoundingClientRect();
-          assert.closeTo(rect.left - (window.innerWidth - rect.right), 0, 5, 'centered horizontally');
-          assert.closeTo(rect.top - (window.innerHeight - rect.bottom), 0, 5, 'centered vertically');
+          assert.closeTo(
+              rect.left - (window.innerWidth - rect.right),
+              0,
+              5,
+              'centered horizontally');
+          assert.closeTo(
+              rect.top - (window.innerHeight - rect.bottom),
+              0,
+              5,
+              'centered vertically');
         });
 
         test('sized element with margin is centered in viewport', function() {
@@ -289,30 +303,48 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           el.classList.add('with-margin');
           el.refit();
           var rect = el.getBoundingClientRect();
-          assert.closeTo(rect.left - (window.innerWidth - rect.right), 0, 5, 'centered horizontally');
-          assert.closeTo(rect.top - (window.innerHeight - rect.bottom), 0, 5, 'centered vertically');
+          assert.closeTo(
+              rect.left - (window.innerWidth - rect.right),
+              0,
+              5,
+              'centered horizontally');
+          assert.closeTo(
+              rect.top - (window.innerHeight - rect.bottom),
+              0,
+              5,
+              'centered vertically');
         });
 
-        test('sized element with transformed parent is centered in viewport', function() {
-          var constrain = fixture('constrain-target');
-          var el = Polymer.dom(constrain).querySelector('.el');
-          var rectBefore = el.getBoundingClientRect();
-          constrain.style.transform = 'translate3d(5px, 5px, 0)';
-          el.center();
-          var rectAfter = el.getBoundingClientRect();
-          assert.equal(rectBefore.top, rectAfter.top, 'top ok');
-          assert.equal(rectBefore.bottom, rectAfter.bottom, 'bottom ok');
-          assert.equal(rectBefore.left, rectAfter.left, 'left ok');
-          assert.equal(rectBefore.right, rectAfter.right, 'right ok');
-        });
+        test(
+            'sized element with transformed parent is centered in viewport',
+            function() {
+              var constrain = fixture('constrain-target');
+              var el = Polymer.dom(constrain).querySelector('.el');
+              var rectBefore = el.getBoundingClientRect();
+              constrain.style.transform = 'translate3d(5px, 5px, 0)';
+              el.center();
+              var rectAfter = el.getBoundingClientRect();
+              assert.equal(rectBefore.top, rectAfter.top, 'top ok');
+              assert.equal(rectBefore.bottom, rectAfter.bottom, 'bottom ok');
+              assert.equal(rectBefore.left, rectAfter.left, 'left ok');
+              assert.equal(rectBefore.right, rectAfter.right, 'right ok');
+            });
 
         test('scrolling element is centered in viewport', function() {
           var el = fixture('sized-x');
           makeScrolling(el);
           el.refit();
           var rect = el.getBoundingClientRect();
-          assert.closeTo(rect.left - (window.innerWidth - rect.right), 0, 5, 'centered horizontally');
-          assert.closeTo(rect.top - (window.innerHeight - rect.bottom), 0, 5, 'centered vertically');
+          assert.closeTo(
+              rect.left - (window.innerWidth - rect.right),
+              0,
+              5,
+              'centered horizontally');
+          assert.closeTo(
+              rect.top - (window.innerHeight - rect.bottom),
+              0,
+              5,
+              'centered vertically');
         });
 
         test('scrolling element is constrained to viewport height', function() {
@@ -320,17 +352,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           makeScrolling(el);
           el.refit();
           var rect = el.getBoundingClientRect();
-          assert.isTrue(rect.height <= window.innerHeight, 'height is less than or equal to viewport height');
+          assert.isTrue(
+              rect.height <= window.innerHeight,
+              'height is less than or equal to viewport height');
         });
 
-        test('scrolling element with offscreen container is constrained to viewport height', function() {
-          var container = fixture('offscreen-container');
-          var el = Polymer.dom(container).querySelector('.el')
-          makeScrolling(el);
-          el.refit();
-          var rect = el.getBoundingClientRect();
-          assert.isTrue(rect.height <= window.innerHeight, 'height is less than or equal to viewport height');
-        });
+        test(
+            'scrolling element with offscreen container is constrained to viewport height',
+            function() {
+              var container = fixture('offscreen-container');
+              var el = Polymer.dom(container).querySelector('.el')
+              makeScrolling(el);
+              el.refit();
+              var rect = el.getBoundingClientRect();
+              assert.isTrue(
+                  rect.height <= window.innerHeight,
+                  'height is less than or equal to viewport height');
+            });
 
         test('scrolling element with max-height is centered in viewport', function() {
           var el = fixture('sized-x');
@@ -338,8 +376,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           makeScrolling(el);
           el.refit();
           var rect = el.getBoundingClientRect();
-          assert.closeTo(rect.left - (window.innerWidth - rect.right), 0, 5, 'centered horizontally');
-          assert.closeTo(rect.top - (window.innerHeight - rect.bottom), 0, 5, 'centered vertically');
+          assert.closeTo(
+              rect.left - (window.innerWidth - rect.right),
+              0,
+              5,
+              'centered horizontally');
+          assert.closeTo(
+              rect.top - (window.innerHeight - rect.bottom),
+              0,
+              5,
+              'centered vertically');
         });
 
         test('scrolling element with max-height respects max-height', function() {
@@ -348,63 +394,93 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           makeScrolling(el);
           el.refit();
           var rect = el.getBoundingClientRect();
-          assert.isTrue(rect.height <= 500, 'height is less than or equal to max-height');
+          assert.isTrue(
+              rect.height <= 500, 'height is less than or equal to max-height');
         });
 
-        test('css positioned, scrolling element is constrained to viewport height (top,left)', function() {
-          var el = fixture('positioned-xy');
-          makeScrolling(el);
-          el.refit();
-          var rect = el.getBoundingClientRect();
-          assert.isTrue(rect.height <= window.innerHeight - 100, 'height is less than or equal to viewport height');
-        });
+        test(
+            'css positioned, scrolling element is constrained to viewport height (top,left)',
+            function() {
+              var el = fixture('positioned-xy');
+              makeScrolling(el);
+              el.refit();
+              var rect = el.getBoundingClientRect();
+              assert.isTrue(
+                  rect.height <= window.innerHeight - 100,
+                  'height is less than or equal to viewport height');
+            });
 
-        test('css positioned, scrolling element is constrained to viewport height (bottom, right)', function() {
-          var el = fixture('sized-x');
-          el.classList.add('positioned-bottom');
-          el.classList.add('positioned-right');
-          el.refit();
-          var rect = el.getBoundingClientRect();
-          assert.isTrue(rect.height <= window.innerHeight - 100, 'height is less than or equal to viewport height');
-        });
+        test(
+            'css positioned, scrolling element is constrained to viewport height (bottom, right)',
+            function() {
+              var el = fixture('sized-x');
+              el.classList.add('positioned-bottom');
+              el.classList.add('positioned-right');
+              el.refit();
+              var rect = el.getBoundingClientRect();
+              assert.isTrue(
+                  rect.height <= window.innerHeight - 100,
+                  'height is less than or equal to viewport height');
+            });
 
-        test('sized, scrolling element with margin is centered in viewport', function() {
-          var el = fixture('sized-x');
-          el.classList.add('with-margin');
-          makeScrolling(el);
-          el.refit();
-          var rect = el.getBoundingClientRect();
-          assert.closeTo(rect.left - (window.innerWidth - rect.right), 0, 5, 'centered horizontally');
-          assert.closeTo(rect.top - (window.innerHeight - rect.bottom), 0, 5, 'centered vertically');
-        });
+        test(
+            'sized, scrolling element with margin is centered in viewport',
+            function() {
+              var el = fixture('sized-x');
+              el.classList.add('with-margin');
+              makeScrolling(el);
+              el.refit();
+              var rect = el.getBoundingClientRect();
+              assert.closeTo(
+                  rect.left - (window.innerWidth - rect.right),
+                  0,
+                  5,
+                  'centered horizontally');
+              assert.closeTo(
+                  rect.top - (window.innerHeight - rect.bottom),
+                  0,
+                  5,
+                  'centered vertically');
+            });
 
-        test('sized, scrolling element is constrained to viewport height', function() {
-          var el = fixture('sized-x');
-          el.classList.add('with-margin');
-          makeScrolling(el);
-          el.refit();
-          var rect = el.getBoundingClientRect();
-          assert.isTrue(rect.height <= window.innerHeight - 20 * 2, 'height is less than or equal to viewport height');
-        });
+        test(
+            'sized, scrolling element is constrained to viewport height', function() {
+              var el = fixture('sized-x');
+              el.classList.add('with-margin');
+              makeScrolling(el);
+              el.refit();
+              var rect = el.getBoundingClientRect();
+              assert.isTrue(
+                  rect.height <= window.innerHeight - 20 * 2,
+                  'height is less than or equal to viewport height');
+            });
 
-        test('css positioned, scrolling element with margin is constrained to viewport height (top, left)', function() {
-          var el = fixture('positioned-xy');
-          el.classList.add('with-margin');
-          makeScrolling(el);
-          el.refit();
-          var rect = el.getBoundingClientRect();
-          assert.isTrue(rect.height <= window.innerHeight - 100 - 20 * 2, 'height is less than or equal to viewport height');
-        });
+        test(
+            'css positioned, scrolling element with margin is constrained to viewport height (top, left)',
+            function() {
+              var el = fixture('positioned-xy');
+              el.classList.add('with-margin');
+              makeScrolling(el);
+              el.refit();
+              var rect = el.getBoundingClientRect();
+              assert.isTrue(
+                  rect.height <= window.innerHeight - 100 - 20 * 2,
+                  'height is less than or equal to viewport height');
+            });
 
-        test('css positioned, scrolling element with margin is constrained to viewport height (bottom, right)', function() {
-          var el = fixture('sized-x');
-          el.classList.add('positioned-bottom');
-          el.classList.add('positioned-right');
-          el.classList.add('with-margin')
-          el.refit();
-          var rect = el.getBoundingClientRect();
-          assert.isTrue(rect.height <= window.innerHeight - 100 - 20 * 2, 'height is less than or equal to viewport height');
-        });
+        test(
+            'css positioned, scrolling element with margin is constrained to viewport height (bottom, right)',
+            function() {
+              var el = fixture('sized-x');
+              el.classList.add('positioned-bottom');
+              el.classList.add('positioned-right');
+              el.classList.add('with-margin')
+              el.refit();
+              var rect = el.getBoundingClientRect();
+              assert.isTrue(
+                  rect.height <= window.innerHeight - 100 - 20 * 2,
+                  'height is less than or equal to viewport height');
+            });
 
         test('scrolling sizingTarget is constrained to viewport height', function() {
           el = fixture('sectioned');
@@ -413,7 +489,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           makeScrolling(internal);
           el.refit();
           var rect = el.getBoundingClientRect();
-          assert.isTrue(rect.height <= window.innerHeight, 'height is less than or equal to viewport height');
+          assert.isTrue(
+              rect.height <= window.innerHeight,
+              'height is less than or equal to viewport height');
         });
 
         test('scrolling sizingTarget preserves scrolling position', function() {
@@ -424,11 +502,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(el.scrollTop, 20, 'scrollTop ok');
           assert.equal(el.scrollLeft, 20, 'scrollLeft ok');
         });
-
       });
 
       suite('fit to element', function() {
-
         test('element fits in another element', function() {
           var constrain = fixture('constrain-target');
           var el = Polymer.dom(constrain).querySelector('.el')
@@ -437,8 +513,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           el.refit();
           var rect = el.getBoundingClientRect();
           var crect = constrain.getBoundingClientRect();
-          assert.isTrue(rect.height <= crect.height, 'width is less than or equal to fitInto width');
-          assert.isTrue(rect.height <= crect.height, 'height is less than or equal to fitInto height');
+          assert.isTrue(
+              rect.height <= crect.height,
+              'width is less than or equal to fitInto width');
+          assert.isTrue(
+              rect.height <= crect.height,
+              'height is less than or equal to fitInto height');
         });
 
         test('element centers in another element', function() {
@@ -449,8 +529,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           el.refit();
           var rect = el.getBoundingClientRect();
           var crect = constrain.getBoundingClientRect();
-          assert.closeTo(rect.left - crect.left - (crect.right - rect.right), 0, 5, 'centered horizontally in fitInto');
-          assert.closeTo(rect.top - crect.top - (crect.bottom - rect.bottom), 0, 5, 'centered vertically in fitInto');
+          assert.closeTo(
+              rect.left - crect.left - (crect.right - rect.right),
+              0,
+              5,
+              'centered horizontally in fitInto');
+          assert.closeTo(
+              rect.top - crect.top - (crect.bottom - rect.bottom),
+              0,
+              5,
+              'centered vertically in fitInto');
         });
 
         test('element with max-width centers in another element', function() {
@@ -461,8 +549,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           el.refit();
           var rect = el.getBoundingClientRect();
           var crect = constrain.getBoundingClientRect();
-          assert.closeTo(rect.left - crect.left - (crect.right - rect.right), 0, 5, 'centered horizontally in fitInto');
-          assert.closeTo(rect.top - crect.top - (crect.bottom - rect.bottom), 0, 5, 'centered vertically in fitInto');
+          assert.closeTo(
+              rect.left - crect.left - (crect.right - rect.right),
+              0,
+              5,
+              'centered horizontally in fitInto');
+          assert.closeTo(
+              rect.top - crect.top - (crect.bottom - rect.bottom),
+              0,
+              5,
+              'centered vertically in fitInto');
         });
 
         test('positioned element fits in another element', function() {
@@ -478,7 +574,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(rect.top, crect.top, 'top ok');
           assert.equal(rect.left, crect.left, 'left ok');
         });
-
       });
 
       suite('horizontal/vertical align', function() {
@@ -501,11 +596,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('intersects works', function() {
-          var base = {top: 0, bottom: 1, left:0, right: 1};
+          var base = {top: 0, bottom: 1, left: 0, right: 1};
           assert.isTrue(intersects(base, base), 'intersects itself');
-          assert.isFalse(intersects(base, {top:1, bottom: 2, left: 0, right: 1}), 'no intersect on edge');
-          assert.isFalse(intersects(base, {top:-2, bottom: -1, left: 0, right: 1}), 'no intersect on edge (negative values)');
-          assert.isFalse(intersects(base, {top:2, bottom: 3, left: 0, right: 1}), 'no intersect');
+          assert.isFalse(
+              intersects(base, {top: 1, bottom: 2, left: 0, right: 1}),
+              'no intersect on edge');
+          assert.isFalse(
+              intersects(base, {top: -2, bottom: -1, left: 0, right: 1}),
+              'no intersect on edge (negative values)');
+          assert.isFalse(
+              intersects(base, {top: 2, bottom: 3, left: 0, right: 1}),
+              'no intersect');
         });
 
         suite('when verticalAlign is top', function() {
@@ -517,18 +618,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.height, elRect.height, 'no cropping');
           });
 
-          test('element is aligned to the positionTarget top without overlapping it', function() {
-            // Allow enough space on the parent's bottom & right.
-            parent.style.width = '10px';
-            parent.style.height = '10px';
-            parentRect = parent.getBoundingClientRect();
-            el.verticalAlign = 'top';
-            el.noOverlap = true;
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.isFalse(intersects(rect, parentRect), 'no overlap');
-            assert.equal(rect.height, elRect.height, 'no cropping');
-          });
+          test(
+              'element is aligned to the positionTarget top without overlapping it',
+              function() {
+                // Allow enough space on the parent's bottom & right.
+                parent.style.width = '10px';
+                parent.style.height = '10px';
+                parentRect = parent.getBoundingClientRect();
+                el.verticalAlign = 'top';
+                el.noOverlap = true;
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.isFalse(intersects(rect, parentRect), 'no overlap');
+                assert.equal(rect.height, elRect.height, 'no cropping');
+              });
 
           test('element margin is considered as offset', function() {
             el.verticalAlign = 'top';
@@ -566,7 +669,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           test('negative verticalOffset does not crop element', function() {
             // Push to the bottom of the screen.
-            parent.style.top = (window.innerHeight - 50) +'px';
+            parent.style.top = (window.innerHeight - 50) + 'px';
             el.verticalAlign = 'top';
             el.verticalOffset = -10;
             el.refit();
@@ -584,27 +687,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.isBelow(rect.height, elRect.height, 'height ok');
           });
 
-          test('min-height is preserved: element is displayed even if partially', function() {
-            parent.style.top = '-10px';
-            el.verticalAlign = 'top';
-            el.style.minHeight = elRect.height + 'px';
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.top, 0, 'top ok');
-            assert.equal(rect.height, elRect.height, 'min-height ok');
-            assert.isTrue(intersects(rect, fitRect), 'partially visible');
-          });
+          test(
+              'min-height is preserved: element is displayed even if partially',
+              function() {
+                parent.style.top = '-10px';
+                el.verticalAlign = 'top';
+                el.style.minHeight = elRect.height + 'px';
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.top, 0, 'top ok');
+                assert.equal(rect.height, elRect.height, 'min-height ok');
+                assert.isTrue(intersects(rect, fitRect), 'partially visible');
+              });
 
-          test('dynamicAlign will prefer bottom align if it minimizes the cropping', function() {
-            parent.style.top = '-10px';
-            parentRect = parent.getBoundingClientRect();
-            el.verticalAlign = 'top';
-            el.dynamicAlign = true;
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.bottom, parentRect.bottom, 'bottom ok');
-            assert.equal(rect.height, elRect.height, 'no cropping');
-          });
+          test(
+              'dynamicAlign will prefer bottom align if it minimizes the cropping',
+              function() {
+                parent.style.top = '-10px';
+                parentRect = parent.getBoundingClientRect();
+                el.verticalAlign = 'top';
+                el.dynamicAlign = true;
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.bottom, parentRect.bottom, 'bottom ok');
+                assert.equal(rect.height, elRect.height, 'no cropping');
+              });
         });
 
         suite('when verticalAlign is bottom', function() {
@@ -616,14 +723,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.height, elRect.height, 'no cropping');
           });
 
-          test('element is aligned to the positionTarget bottom without overlapping it', function() {
-            el.verticalAlign = 'bottom';
-            el.noOverlap = true;
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.isFalse(intersects(rect, parentRect), 'no overlap');
-            assert.equal(rect.height, elRect.height, 'no cropping');
-          });
+          test(
+              'element is aligned to the positionTarget bottom without overlapping it',
+              function() {
+                el.verticalAlign = 'bottom';
+                el.noOverlap = true;
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.isFalse(intersects(rect, parentRect), 'no overlap');
+                assert.equal(rect.height, elRect.height, 'no cropping');
+              });
 
           test('element margin is considered as offset', function() {
             el.verticalAlign = 'bottom';
@@ -668,27 +777,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.height, 100, 'height ok');
           });
 
-          test('min-height is preserved: element is displayed even if partially', function() {
-            parent.style.top = (elRect.height - 10 - parentRect.height) + 'px';
-            el.verticalAlign = 'bottom';
-            el.style.minHeight = elRect.height + 'px';
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.top, 0, 'top ok');
-            assert.equal(rect.height, elRect.height, 'min-height ok');
-            assert.isTrue(intersects(rect, fitRect), 'partially visible');
-          });
+          test(
+              'min-height is preserved: element is displayed even if partially',
+              function() {
+                parent.style.top = (elRect.height - 10 - parentRect.height) + 'px';
+                el.verticalAlign = 'bottom';
+                el.style.minHeight = elRect.height + 'px';
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.top, 0, 'top ok');
+                assert.equal(rect.height, elRect.height, 'min-height ok');
+                assert.isTrue(intersects(rect, fitRect), 'partially visible');
+              });
 
-          test('dynamicAlign will prefer top align if it minimizes the cropping', function() {
-            parent.style.top = (window.innerHeight - elRect.height) + 'px';
-            parentRect = parent.getBoundingClientRect();
-            el.verticalAlign = 'bottom';
-            el.dynamicAlign = true;
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.top, parentRect.top, 'top ok');
-            assert.equal(rect.height, elRect.height, 'no cropping');
-          });
+          test(
+              'dynamicAlign will prefer top align if it minimizes the cropping',
+              function() {
+                parent.style.top = (window.innerHeight - elRect.height) + 'px';
+                parentRect = parent.getBoundingClientRect();
+                el.verticalAlign = 'bottom';
+                el.dynamicAlign = true;
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.top, parentRect.top, 'top ok');
+                assert.equal(rect.height, elRect.height, 'no cropping');
+              });
         });
 
         suite('when verticalAlign is middle', function() {
@@ -696,32 +809,43 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             el.verticalAlign = 'middle';
             el.refit();
             var rect = el.getBoundingClientRect();
-            assert.equal(rect.top, parentRect.top + (parentRect.height - rect.height) / 2, 'top ok');
+            assert.equal(
+                rect.top,
+                parentRect.top + (parentRect.height - rect.height) / 2,
+                'top ok');
             assert.equal(rect.height, elRect.height, 'no cropping');
           });
 
-          test('element is aligned to the positionTarget top without overlapping it', function() {
-            // Allow enough space on the parent's bottom & right.
-            el.verticalAlign = 'middle';
-            el.noOverlap = true;
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.isFalse(intersects(rect, parentRect), 'no overlap');
-            assert.equal(rect.height, elRect.height, 'no cropping');
-          });
+          test(
+              'element is aligned to the positionTarget top without overlapping it',
+              function() {
+                // Allow enough space on the parent's bottom & right.
+                el.verticalAlign = 'middle';
+                el.noOverlap = true;
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.isFalse(intersects(rect, parentRect), 'no overlap');
+                assert.equal(rect.height, elRect.height, 'no cropping');
+              });
 
           test('element margin is considered as offset', function() {
             el.verticalAlign = 'middle';
             el.style.marginTop = '10px';
             el.refit();
             var rect = el.getBoundingClientRect();
-            assert.equal(rect.top, parentRect.top + (parentRect.height - rect.height) / 2 + 10, 'top ok');
+            assert.equal(
+                rect.top,
+                parentRect.top + (parentRect.height - rect.height) / 2 + 10,
+                'top ok');
             assert.equal(rect.height, elRect.height, 'no cropping');
 
             el.style.marginTop = '-10px';
             el.refit();
             rect = el.getBoundingClientRect();
-            assert.equal(rect.top, parentRect.top + (parentRect.height - rect.height) / 2 - 10, 'top ok');
+            assert.equal(
+                rect.top,
+                parentRect.top + (parentRect.height - rect.height) / 2 - 10,
+                'top ok');
             assert.equal(rect.height, elRect.height, 'no cropping');
           });
 
@@ -730,7 +854,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             el.verticalOffset = 10;
             el.refit();
             var rect = el.getBoundingClientRect();
-            assert.equal(rect.top, parentRect.top + (parentRect.height - rect.height) / 2 + 10, 'top ok');
+            assert.equal(
+                rect.top,
+                parentRect.top + (parentRect.height - rect.height) / 2 + 10,
+                'top ok');
             assert.equal(rect.height, elRect.height, 'no cropping');
           });
 
@@ -746,7 +873,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           test('negative verticalOffset does not crop element', function() {
             // Push to the bottom of the screen.
-            parent.style.top = (window.innerHeight - 50) +'px';
+            parent.style.top = (window.innerHeight - 50) + 'px';
             el.verticalAlign = 'middle';
             el.verticalOffset = -10;
             el.refit();
@@ -764,27 +891,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.isBelow(rect.height, elRect.height, 'height ok');
           });
 
-          test('min-height is preserved: element is displayed even if partially', function() {
-            parent.style.top = '-50px';
-            el.verticalAlign = 'middle';
-            el.style.minHeight = elRect.height + 'px';
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.top, 0, 'top ok');
-            assert.equal(rect.height, elRect.height, 'min-height ok');
-            assert.isTrue(intersects(rect, fitRect), 'partially visible');
-          });
+          test(
+              'min-height is preserved: element is displayed even if partially',
+              function() {
+                parent.style.top = '-50px';
+                el.verticalAlign = 'middle';
+                el.style.minHeight = elRect.height + 'px';
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.top, 0, 'top ok');
+                assert.equal(rect.height, elRect.height, 'min-height ok');
+                assert.isTrue(intersects(rect, fitRect), 'partially visible');
+              });
 
-          test('dynamicAlign will prefer bottom align if it minimizes the cropping', function() {
-            parent.style.top = '-50px';
-            parentRect = parent.getBoundingClientRect();
-            el.verticalAlign = 'middle';
-            el.dynamicAlign = true;
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.bottom, parentRect.bottom, 'bottom ok');
-            assert.equal(rect.height, elRect.height, 'no cropping');
-          });
+          test(
+              'dynamicAlign will prefer bottom align if it minimizes the cropping',
+              function() {
+                parent.style.top = '-50px';
+                parentRect = parent.getBoundingClientRect();
+                el.verticalAlign = 'middle';
+                el.dynamicAlign = true;
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.bottom, parentRect.bottom, 'bottom ok');
+                assert.equal(rect.height, elRect.height, 'no cropping');
+              });
         });
 
         suite('when verticalAlign is auto', function() {
@@ -796,43 +927,50 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.height, elRect.height, 'no cropping');
           });
 
-          test('element is aligned to the positionTarget top without overlapping it', function() {
-            // Allow enough space on the parent's bottom & right.
-            parent.style.width = '10px';
-            parent.style.height = '10px';
-            parentRect = parent.getBoundingClientRect();
-            el.verticalAlign = 'auto';
-            el.noOverlap = true;
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.height, elRect.height, 'no cropping');
-            assert.isFalse(intersects(rect, parentRect), 'no overlap');
-          });
+          test(
+              'element is aligned to the positionTarget top without overlapping it',
+              function() {
+                // Allow enough space on the parent's bottom & right.
+                parent.style.width = '10px';
+                parent.style.height = '10px';
+                parentRect = parent.getBoundingClientRect();
+                el.verticalAlign = 'auto';
+                el.noOverlap = true;
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.height, elRect.height, 'no cropping');
+                assert.isFalse(intersects(rect, parentRect), 'no overlap');
+              });
 
-          test('bottom is preferred to top if it diminishes the cropped area', function() {
-            // This would cause a cropping of the element, so it should automatically
-            // align to the bottom to avoid it.
-            parent.style.top = '-10px';
-            parentRect = parent.getBoundingClientRect();
-            el.verticalAlign = 'auto';
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.bottom, parentRect.bottom, 'auto aligned to bottom');
-            assert.equal(rect.height, elRect.height, 'no cropping');
-          });
+          test(
+              'bottom is preferred to top if it diminishes the cropped area',
+              function() {
+                // This would cause a cropping of the element, so it should
+                // automatically align to the bottom to avoid it.
+                parent.style.top = '-10px';
+                parentRect = parent.getBoundingClientRect();
+                el.verticalAlign = 'auto';
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(
+                    rect.bottom, parentRect.bottom, 'auto aligned to bottom');
+                assert.equal(rect.height, elRect.height, 'no cropping');
+              });
 
-          test('bottom is preferred to top if it diminishes the cropped area, without overlapping positionTarget', function() {
-            // This would cause a cropping of the element, so it should automatically
-            // align to the bottom to avoid it.
-            parent.style.top = '-10px';
-            parentRect = parent.getBoundingClientRect();
-            el.verticalAlign = 'auto';
-            el.noOverlap = true;
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.height, elRect.height, 'no cropping');
-            assert.isFalse(intersects(rect, parentRect), 'no overlap');
-          });
+          test(
+              'bottom is preferred to top if it diminishes the cropped area, without overlapping positionTarget',
+              function() {
+                // This would cause a cropping of the element, so it should
+                // automatically align to the bottom to avoid it.
+                parent.style.top = '-10px';
+                parentRect = parent.getBoundingClientRect();
+                el.verticalAlign = 'auto';
+                el.noOverlap = true;
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.height, elRect.height, 'no cropping');
+                assert.isFalse(intersects(rect, parentRect), 'no overlap');
+              });
         });
 
         suite('when horizontalAlign is left', function() {
@@ -844,17 +982,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.width, elRect.width, 'no cropping');
           });
 
-          test('element is aligned to the positionTarget left without overlapping it', function() {
-            // Make space at the parent's right.
-            parent.style.width = '10px';
-            parentRect = parent.getBoundingClientRect();
-            el.horizontalAlign = 'left';
-            el.noOverlap = true;
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.isFalse(intersects(rect, parentRect), 'no overlap');
-            assert.equal(rect.width, elRect.width, 'no cropping');
-          });
+          test(
+              'element is aligned to the positionTarget left without overlapping it',
+              function() {
+                // Make space at the parent's right.
+                parent.style.width = '10px';
+                parentRect = parent.getBoundingClientRect();
+                el.horizontalAlign = 'left';
+                el.noOverlap = true;
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.isFalse(intersects(rect, parentRect), 'no overlap');
+                assert.equal(rect.width, elRect.width, 'no cropping');
+              });
 
           test('element margin is considered as offset', function() {
             el.horizontalAlign = 'left';
@@ -892,7 +1032,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           test('negative horizontalOffset does not crop element', function() {
             // Push to the bottom of the screen.
-            parent.style.left = (window.innerWidth - 50) +'px';
+            parent.style.left = (window.innerWidth - 50) + 'px';
             el.horizontalAlign = 'left';
             el.horizontalOffset = -10;
             el.refit();
@@ -910,28 +1050,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.isBelow(rect.width, elRect.width, 'width ok');
           });
 
-          test('min-width is preserved: element is displayed even if partially', function() {
-            parent.style.left = '-10px';
-            el.style.minWidth = elRect.width + 'px';
-            el.horizontalAlign = 'left';
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.left, 0, 'left ok');
-            assert.equal(rect.width, elRect.width, 'min-width ok');
-            assert.isTrue(intersects(rect, fitRect), 'partially visible');
-          });
+          test(
+              'min-width is preserved: element is displayed even if partially',
+              function() {
+                parent.style.left = '-10px';
+                el.style.minWidth = elRect.width + 'px';
+                el.horizontalAlign = 'left';
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.left, 0, 'left ok');
+                assert.equal(rect.width, elRect.width, 'min-width ok');
+                assert.isTrue(intersects(rect, fitRect), 'partially visible');
+              });
 
-          test('dynamicAlign will prefer right align if it minimizes the cropping', function() {
-            parent.style.left = '-10px';
-            parentRect = parent.getBoundingClientRect();
-            el.horizontalAlign = 'left';
-            el.dynamicAlign = true;
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.right, parentRect.right, 'right ok');
-            assert.equal(rect.height, elRect.height, 'no cropping');
-          });
-
+          test(
+              'dynamicAlign will prefer right align if it minimizes the cropping',
+              function() {
+                parent.style.left = '-10px';
+                parentRect = parent.getBoundingClientRect();
+                el.horizontalAlign = 'left';
+                el.dynamicAlign = true;
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.right, parentRect.right, 'right ok');
+                assert.equal(rect.height, elRect.height, 'no cropping');
+              });
         });
 
         suite('when horizontalAlign is right', function() {
@@ -943,17 +1086,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.width, elRect.width, 'no cropping');
           });
 
-          test('element is aligned to the positionTarget right without overlapping it', function() {
-            // Make space at the parent's left.
-            parent.style.left = elRect.width + 'px';
-            parentRect = parent.getBoundingClientRect();
-            el.horizontalAlign = 'right';
-            el.noOverlap = true;
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.isFalse(intersects(rect, parentRect), 'no overlap');
-            assert.equal(rect.width, elRect.width, 'no cropping');
-          });
+          test(
+              'element is aligned to the positionTarget right without overlapping it',
+              function() {
+                // Make space at the parent's left.
+                parent.style.left = elRect.width + 'px';
+                parentRect = parent.getBoundingClientRect();
+                el.horizontalAlign = 'right';
+                el.noOverlap = true;
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.isFalse(intersects(rect, parentRect), 'no overlap');
+                assert.equal(rect.width, elRect.width, 'no cropping');
+              });
 
           test('element margin is considered as offset', function() {
             el.horizontalAlign = 'right';
@@ -998,28 +1143,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.width, 100, 'width ok');
           });
 
-          test('min-width is preserved: element is displayed even if partially', function() {
-            parent.style.left = (elRect.width - 10 - parentRect.width) + 'px';
-            el.horizontalAlign = 'right';
-            el.style.minWidth = elRect.width + 'px';
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.left, 0, 'left ok');
-            assert.equal(rect.width, elRect.width, 'min-width ok');
-            assert.isTrue(intersects(rect, fitRect), 'partially visible');
-          });
+          test(
+              'min-width is preserved: element is displayed even if partially',
+              function() {
+                parent.style.left = (elRect.width - 10 - parentRect.width) + 'px';
+                el.horizontalAlign = 'right';
+                el.style.minWidth = elRect.width + 'px';
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.left, 0, 'left ok');
+                assert.equal(rect.width, elRect.width, 'min-width ok');
+                assert.isTrue(intersects(rect, fitRect), 'partially visible');
+              });
 
-          test('dynamicAlign will prefer left align if it minimizes the cropping', function() {
-            parent.style.left = (window.innerWidth - elRect.width) + 'px';
-            parentRect = parent.getBoundingClientRect();
-            el.horizontalAlign = 'right';
-            el.dynamicAlign = true;
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.left, parentRect.left, 'left ok');
-            assert.equal(rect.height, elRect.height, 'no cropping');
-          });
-
+          test(
+              'dynamicAlign will prefer left align if it minimizes the cropping',
+              function() {
+                parent.style.left = (window.innerWidth - elRect.width) + 'px';
+                parentRect = parent.getBoundingClientRect();
+                el.horizontalAlign = 'right';
+                el.dynamicAlign = true;
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.left, parentRect.left, 'left ok');
+                assert.equal(rect.height, elRect.height, 'no cropping');
+              });
         });
 
         suite('when horizontalAlign is center', function() {
@@ -1027,31 +1175,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             el.horizontalAlign = 'center';
             el.refit();
             var rect = el.getBoundingClientRect();
-            assert.equal(rect.left, parentRect.left + (parentRect.width - rect.width) / 2, 'left ok');
+            assert.equal(
+                rect.left,
+                parentRect.left + (parentRect.width - rect.width) / 2,
+                'left ok');
             assert.equal(rect.width, elRect.width, 'no cropping');
           });
 
-          test('element is aligned to the positionTarget left without overlapping it', function() {
-            el.horizontalAlign = 'center';
-            el.noOverlap = true;
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.isFalse(intersects(rect, parentRect), 'no overlap');
-            assert.equal(rect.width, elRect.width, 'no cropping');
-          });
+          test(
+              'element is aligned to the positionTarget left without overlapping it',
+              function() {
+                el.horizontalAlign = 'center';
+                el.noOverlap = true;
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.isFalse(intersects(rect, parentRect), 'no overlap');
+                assert.equal(rect.width, elRect.width, 'no cropping');
+              });
 
           test('element margin is considered as offset', function() {
             el.horizontalAlign = 'center';
             el.style.marginLeft = '10px';
             el.refit();
             var rect = el.getBoundingClientRect();
-            assert.equal(rect.left, parentRect.left + (parentRect.width - rect.width) / 2 + 10, 'left ok');
+            assert.equal(
+                rect.left,
+                parentRect.left + (parentRect.width - rect.width) / 2 + 10,
+                'left ok');
             assert.equal(rect.width, elRect.width, 'no cropping');
 
             el.style.marginLeft = '-10px';
             el.refit();
             rect = el.getBoundingClientRect();
-            assert.equal(rect.left, parentRect.left + (parentRect.width - rect.width) / 2 - 10, 'left ok');
+            assert.equal(
+                rect.left,
+                parentRect.left + (parentRect.width - rect.width) / 2 - 10,
+                'left ok');
             assert.equal(rect.width, elRect.width, 'no cropping');
           });
 
@@ -1060,7 +1219,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             el.horizontalOffset = 10;
             el.refit();
             var rect = el.getBoundingClientRect();
-            assert.equal(rect.left, parentRect.left + (parentRect.width - rect.width) / 2 + 10, 'left ok');
+            assert.equal(
+                rect.left,
+                parentRect.left + (parentRect.width - rect.width) / 2 + 10,
+                'left ok');
             assert.equal(rect.width, elRect.width, 'no cropping');
           });
 
@@ -1076,7 +1238,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           test('negative horizontalOffset does not crop element', function() {
             // Push to the bottom of the screen.
-            parent.style.left = (window.innerWidth - 50) +'px';
+            parent.style.left = (window.innerWidth - 50) + 'px';
             el.horizontalAlign = 'center';
             el.horizontalOffset = -10;
             el.refit();
@@ -1094,28 +1256,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.isBelow(rect.width, elRect.width, 'width ok');
           });
 
-          test('min-width is preserved: element is displayed even if partially', function() {
-            parent.style.left = '-50px';
-            el.style.minWidth = elRect.width + 'px';
-            el.horizontalAlign = 'center';
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.left, 0, 'left ok');
-            assert.equal(rect.width, elRect.width, 'min-width ok');
-            assert.isTrue(intersects(rect, fitRect), 'partially visible');
-          });
+          test(
+              'min-width is preserved: element is displayed even if partially',
+              function() {
+                parent.style.left = '-50px';
+                el.style.minWidth = elRect.width + 'px';
+                el.horizontalAlign = 'center';
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.left, 0, 'left ok');
+                assert.equal(rect.width, elRect.width, 'min-width ok');
+                assert.isTrue(intersects(rect, fitRect), 'partially visible');
+              });
 
-          test('dynamicAlign will prefer right align if it minimizes the cropping', function() {
-            parent.style.left = '-50px';
-            parentRect = parent.getBoundingClientRect();
-            el.horizontalAlign = 'center';
-            el.dynamicAlign = true;
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.right, parentRect.right, 'right ok');
-            assert.equal(rect.height, elRect.height, 'no cropping');
-          });
-
+          test(
+              'dynamicAlign will prefer right align if it minimizes the cropping',
+              function() {
+                parent.style.left = '-50px';
+                parentRect = parent.getBoundingClientRect();
+                el.horizontalAlign = 'center';
+                el.dynamicAlign = true;
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.right, parentRect.right, 'right ok');
+                assert.equal(rect.height, elRect.height, 'no cropping');
+              });
         });
 
         suite('when horizontalAlign is auto', function() {
@@ -1127,41 +1292,47 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.width, elRect.width, 'no cropping');
           });
 
-          test('element is aligned to the positionTarget left without overlapping positionTarget', function() {
-            // Make space at the parent's left.
-            parent.style.left = elRect.width + 'px';
-            parentRect = parent.getBoundingClientRect();
-            el.horizontalAlign = 'auto';
-            el.noOverlap = true;
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.width, elRect.width, 'no cropping');
-            assert.isFalse(intersects(rect, parentRect), 'no overlap');
-          });
+          test(
+              'element is aligned to the positionTarget left without overlapping positionTarget',
+              function() {
+                // Make space at the parent's left.
+                parent.style.left = elRect.width + 'px';
+                parentRect = parent.getBoundingClientRect();
+                el.horizontalAlign = 'auto';
+                el.noOverlap = true;
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.width, elRect.width, 'no cropping');
+                assert.isFalse(intersects(rect, parentRect), 'no overlap');
+              });
 
-          test('right is preferred to left if it diminishes the cropped area', function() {
-            // This would cause a cropping of the element, so it should automatically
-            // align to the right to avoid it.
-            parent.style.left = '-10px';
-            parentRect = parent.getBoundingClientRect();
-            el.horizontalAlign = 'auto';
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.right, parentRect.right, 'auto aligned to right');
-            assert.equal(rect.width, elRect.width, 'no cropping');
-          });
+          test(
+              'right is preferred to left if it diminishes the cropped area',
+              function() {
+                // This would cause a cropping of the element, so it should
+                // automatically align to the right to avoid it.
+                parent.style.left = '-10px';
+                parentRect = parent.getBoundingClientRect();
+                el.horizontalAlign = 'auto';
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.right, parentRect.right, 'auto aligned to right');
+                assert.equal(rect.width, elRect.width, 'no cropping');
+              });
 
-          test('right is preferred to left if it diminishes the cropped area, without overlapping positionTarget', function() {
-            // Make space at the parent's right.
-            parent.style.width = '10px';
-            parentRect = parent.getBoundingClientRect();
-            el.horizontalAlign = 'auto';
-            el.noOverlap = true;
-            el.refit();
-            var rect = el.getBoundingClientRect();
-            assert.equal(rect.width, elRect.width, 'no cropping');
-            assert.isFalse(intersects(rect, parentRect), 'no overlap');
-          });
+          test(
+              'right is preferred to left if it diminishes the cropped area, without overlapping positionTarget',
+              function() {
+                // Make space at the parent's right.
+                parent.style.width = '10px';
+                parentRect = parent.getBoundingClientRect();
+                el.horizontalAlign = 'auto';
+                el.noOverlap = true;
+                el.refit();
+                var rect = el.getBoundingClientRect();
+                assert.equal(rect.width, elRect.width, 'no cropping');
+                assert.isFalse(intersects(rect, parentRect), 'no overlap');
+              });
         });
 
         suite('prefer horizontal overlap to vertical overlap', function() {
@@ -1211,9 +1382,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(rect.right, parentRect.right, 'right ok');
             assert.equal(rect.bottom, parentRect.top, 'bottom ok');
           });
-
         });
-
       });
     </script>
 

--- a/test/test-fit.html
+++ b/test/test-fit.html
@@ -23,11 +23,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <slot></slot>
   </template>
   <script>
-    Polymer({
-      is: 'test-fit',
-      behaviors: [
-        Polymer.IronFitBehavior
-      ]
-    });
+    Polymer({is: 'test-fit', behaviors: [Polymer.IronFitBehavior]});
   </script>
 </dom-module>


### PR DESCRIPTION
Runs the experimental autoformatter [webmat](https://github.com/PolymerLabs/webmat) which runs clang-format on js files and makes it so that it can run on HTML files. Please look through this PR with `?w=1` in the diff to make sure that no logic was changed.

What has changed?
You can run the formatter on the whole project by running `npm run format` and ex/include files from the formatter, and enter your custom clang-format config in a formatconfig.json see webmat readme for more