### PR TITLE
Lazily calculate and memoize __isRTL property in iron-fit-behavior.

### DIFF
--- a/iron-fit-behavior.js
+++ b/iron-fit-behavior.js
@@ -235,13 +235,21 @@ export const IronFitBehavior = {
     return (this.horizontalAlign || this.verticalAlign) && this.positionTarget;
   },
 
-  /** @override */
-  attached: function() {
+  /**
+   * True if the component is RTL.
+   * @private
+   */
+  get _isRTL() {
     // Memoize this to avoid expensive calculations & relayouts.
     // Make sure we do it only once
-    if (typeof this._isRTL === 'undefined') {
-      this._isRTL = window.getComputedStyle(this).direction == 'rtl';
+    if (typeof this._memoizedIsRTL === 'undefined') {
+      this._memoizedIsRTL = window.getComputedStyle(this).direction == 'rtl';
     }
+    return this._memoizedIsRTL;
+  },
+
+  /** @override */
+  attached: function() {
     this.positionTarget = this.positionTarget || this._defaultPositionTarget;
     if (this.autoFitOnAttach) {
       if (window.getComputedStyle(this).display === 'none') {


### PR DESCRIPTION
Calling window.getComputedStyles(this) is expensive (~80ms) and is done in attached() now, which impact page load time (rendering).

Instead we could calculate it when it is accessed for the first time.